### PR TITLE
ci: speed up e2e build and cluster setup

### DIFF
--- a/.github/workflows/test-environment-validation.yaml
+++ b/.github/workflows/test-environment-validation.yaml
@@ -72,6 +72,12 @@ jobs:
       - name: Generate code
         run: task generate:code
 
+      - name: Start cluster creation in background
+        run: |
+          task test-infra:cluster-up > /tmp/cluster-up.log 2>&1 &
+          echo $! > /tmp/cluster-up.pid
+          echo "Cluster creation started in background (PID: $(cat /tmp/cluster-up.pid))"
+
       - name: Build Milo container image with caching
         uses: docker/build-push-action@v5
         with:
@@ -85,17 +91,24 @@ jobs:
           build-args: |
             GOPROXY=https://proxy.golang.org,direct
 
-      - name: Set up test infrastructure cluster
+      - name: Wait for cluster creation
         run: |
-          echo "Setting up test infrastructure cluster (using pre-built image)..."
+          PID=$(cat /tmp/cluster-up.pid)
+          echo "Waiting for background cluster creation (PID: $PID)..."
+          if wait "$PID"; then
+            echo "✓ Cluster creation completed successfully"
+          else
+            echo "✗ Cluster creation failed — logs:"
+            cat /tmp/cluster-up.log
+            exit 1
+          fi
 
-          # Create the KinD cluster
-          task test-infra:cluster-up
-
-          # Load the pre-built image (will skip build since image exists)
+      - name: Deploy Milo to test cluster
+        run: |
+          # Load the pre-built image into the now-ready cluster
           task dev:load
 
-          # Deploy Milo control plane (dependencies already satisfied)
+          # Deploy Milo control plane
           task dev:deploy
 
       - name: Wait for networking path to be ready

--- a/.github/workflows/test-environment-validation.yaml
+++ b/.github/workflows/test-environment-validation.yaml
@@ -69,6 +69,9 @@ jobs:
           kind version
           echo "Go version: $(go version)"
 
+      - name: Generate code
+        run: task generate:code
+
       - name: Build Milo container image with caching
         uses: docker/build-push-action@v5
         with:
@@ -88,9 +91,6 @@ jobs:
 
           # Create the KinD cluster
           task test-infra:cluster-up
-
-          # Generate required code
-          task generate:code
 
           # Load the pre-built image (will skip build since image exists)
           task dev:load

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ WORKDIR /app
 COPY go.mod go.sum ./
 
 # Download dependencies (cached when go.mod/go.sum don't change)
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 # Copy the rest of the application source code
 COPY . .
@@ -28,7 +29,9 @@ ARG VERSION=v0.0.0-master+dev
 ARG GIT_COMMIT=unknown
 ARG GIT_TREE_STATE=dirty
 ARG BUILD_DATE=unknown
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
     go build -trimpath -o milo ./cmd/milo
 
 # Final stage: minimal runtime image


### PR DESCRIPTION
## Summary

- Add BuildKit \`--mount=type=cache\` for \`/go/pkg/mod\` and \`/root/.cache/go-build\` in the Dockerfile so the Go compiler and module caches persist across runs via the GHA layer cache
- Move \`generate:code\` to its own step before the Docker build — it has no dependency on the cluster and was blocking behind KinD creation
- Parallelize \`test-infra:cluster-up\` and the Docker image build by starting cluster creation in the background immediately before the \`docker/build-push-action\` step

## Background

The \`test-environment-validation\` job was spending ~13 minutes before tests even started:

| Step | Time |
|------|------|
| Build Milo container image | ~6m41s |
| Set up test infrastructure cluster | ~5m27s |

**Build slowness:** \`cache-from: type=gha\` caches Docker layers, but \`COPY . .\` invalidates the layer on every PR, triggering a full \`go build\` from scratch. Without \`--mount=type=cache\`, the Go build cache is discarded between runs.

**Sequential bottleneck:** Cluster creation and the Docker build are fully independent — they only converge at \`dev:load\`. Running them one after the other wastes ~5 minutes of wall-clock time.

## How the parallelism works

Cluster creation is IO-bound (pulling images, waiting on pod readiness) while the Docker build is CPU-bound, so they coexist well on the same runner. A "Start cluster creation in background" step fires \`task test-infra:cluster-up\` into the background before the \`docker/build-push-action\` step runs. A "Wait for cluster creation" step afterward collects the exit code and surfaces the full log on failure.

## Expected improvement

| Change | Savings |
|--------|---------|
| Go build cache mounts | ~3-5m after first warm cache hit |
| Parallel cluster + image build | ~5m per run |

- **Cold run** (first after merge): similar to before
- **Warm runs**: should drop from ~13m to ~8m before tests start

## Test plan

- [ ] Confirm the workflow triggers on this PR
- [ ] Verify "Generate code" step passes and generated files are available for the Docker build
- [ ] Check cluster creation log surfaces correctly in the "Wait for cluster creation" step
- [ ] Confirm "Build Milo container image" and cluster creation visibly overlap in the step timestamps
- [ ] Check that the Docker build step is faster on a second run of the same branch (warm cache)
- [ ] Confirm e2e tests still pass end-to-end