### PR TITLE
test: migrate project-lifecycle from infra (WIP)

### DIFF
--- a/test/resource-management/project-lifecycle/01-test-organization.yaml
+++ b/test/resource-management/project-lifecycle/01-test-organization.yaml
@@ -1,0 +1,11 @@
+apiVersion: resourcemanager.miloapis.com/v1alpha1
+kind: Organization
+metadata:
+  name: test-project-lifecycle-org
+  labels:
+    test.miloapis.com/scenario: "project-lifecycle"
+  annotations:
+    kubernetes.io/description: "Organization for testing project lifecycle"
+    kubernetes.io/display-name: "Test Project Lifecycle Organization"
+spec:
+  type: Standard

--- a/test/resource-management/project-lifecycle/02-test-user.yaml
+++ b/test/resource-management/project-lifecycle/02-test-user.yaml
@@ -1,0 +1,10 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: User
+metadata:
+  name: user-admin
+  labels:
+    test.miloapis.com/scenario: "project-lifecycle"
+spec:
+  email: admin@test.local
+  givenName: ProjectTest
+  familyName: Admin

--- a/test/resource-management/project-lifecycle/03-organization-membership.yaml
+++ b/test/resource-management/project-lifecycle/03-organization-membership.yaml
@@ -1,0 +1,12 @@
+apiVersion: resourcemanager.miloapis.com/v1alpha1
+kind: OrganizationMembership
+metadata:
+  name: user-admin-membership
+  namespace: organization-test-project-lifecycle-org
+  labels:
+    test.miloapis.com/scenario: "project-lifecycle"
+spec:
+  organizationRef:
+    name: test-project-lifecycle-org
+  userRef:
+    name: "user-admin"

--- a/test/resource-management/project-lifecycle/04-test-project.yaml
+++ b/test/resource-management/project-lifecycle/04-test-project.yaml
@@ -1,0 +1,10 @@
+apiVersion: resourcemanager.miloapis.com/v1alpha1
+kind: Project
+metadata:
+  name: project-lifecycle-test
+  labels:
+    test.miloapis.com/scenario: "project-lifecycle"
+spec:
+  ownerRef:
+    kind: Organization
+    name: test-project-lifecycle-org

--- a/test/resource-management/project-lifecycle/assertions/assert-project-exists-main.yaml
+++ b/test/resource-management/project-lifecycle/assertions/assert-project-exists-main.yaml
@@ -1,0 +1,11 @@
+apiVersion: resourcemanager.miloapis.com/v1alpha1
+kind: Project
+metadata:
+  name: project-lifecycle-test
+  labels:
+    test.miloapis.com/scenario: "project-lifecycle"
+    resourcemanager.miloapis.com/organization-name: test-project-lifecycle-org
+spec:
+  ownerRef:
+    kind: Organization
+    name: test-project-lifecycle-org

--- a/test/resource-management/project-lifecycle/assertions/assert-project-ready.yaml
+++ b/test/resource-management/project-lifecycle/assertions/assert-project-ready.yaml
@@ -1,0 +1,21 @@
+apiVersion: resourcemanager.miloapis.com/v1alpha1
+kind: Project
+metadata:
+  name: project-lifecycle-test
+  labels:
+    test.miloapis.com/scenario: "project-lifecycle"
+    resourcemanager.miloapis.com/organization-name: test-project-lifecycle-org
+  ownerReferences:
+  - apiVersion: resourcemanager.miloapis.com/v1alpha1
+    kind: Organization
+    name: test-project-lifecycle-org
+spec:
+  ownerRef:
+    kind: Organization
+    name: test-project-lifecycle-org
+status:
+  conditions:
+  - type: Ready
+    status: "True"
+    reason: Ready
+    message: Project is ready

--- a/test/resource-management/project-lifecycle/chainsaw-test.yaml
+++ b/test/resource-management/project-lifecycle/chainsaw-test.yaml
@@ -1,0 +1,108 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: project-lifecycle
+spec:
+  description: |
+    Tests the full Project lifecycle against the resourcemanager.miloapis.com
+    API contract.
+
+    This test verifies:
+    - A Project can be created within an Organization control plane
+    - The Project reaches Ready status
+    - The Project is visible (listed) in both organization and main cluster
+      contexts
+    - The Project can be deleted and is fully removed from both contexts
+
+    Migrated from datum-cloud/infra (infra#3006). The original ran against a
+    live environment via datumctl auth; this variant runs against the local
+    Milo apiserver control planes.
+
+  clusters:
+    main:
+      kubeconfig: kubeconfig-main
+    org:
+      kubeconfig: kubeconfig-org-template
+
+  steps:
+    - name: setup-organization
+      description: Create Organization, User, and OrganizationMembership for project testing
+      try:
+        - apply:
+            file: 01-test-organization.yaml
+        - wait:
+            apiVersion: v1
+            kind: Namespace
+            name: organization-test-project-lifecycle-org
+            timeout: 30s
+            for:
+              jsonPath:
+                path: '{.status.phase}'
+                value: Active
+        - apply:
+            file: 02-test-user.yaml
+        - wait:
+            apiVersion: iam.miloapis.com/v1alpha1
+            kind: User
+            name: "user-admin"
+            timeout: 30s
+            for:
+              condition:
+                name: Ready
+                value: 'True'
+        - apply:
+            file: 03-organization-membership.yaml
+
+    - name: create-project-and-wait-for-ready
+      description: Create Project in organization context and verify it reaches Ready status
+      cluster: org
+      try:
+        - apply:
+            file: 04-test-project.yaml
+        - wait:
+            apiVersion: resourcemanager.miloapis.com/v1alpha1
+            kind: Project
+            name: project-lifecycle-test
+            timeout: 60s
+            for:
+              condition:
+                name: Ready
+                value: 'True'
+        - assert:
+            file: assertions/assert-project-ready.yaml
+
+    - name: verify-project-listed-in-main-cluster
+      description: Verify the Project is visible in the main cluster context
+      cluster: main
+      try:
+        - assert:
+            file: assertions/assert-project-exists-main.yaml
+
+    - name: delete-project
+      description: Delete the Project and verify it is removed from the organization context
+      cluster: org
+      try:
+        - delete:
+            ref:
+              apiVersion: resourcemanager.miloapis.com/v1alpha1
+              kind: Project
+              name: project-lifecycle-test
+        - wait:
+            apiVersion: resourcemanager.miloapis.com/v1alpha1
+            kind: Project
+            name: project-lifecycle-test
+            timeout: 120s
+            for:
+              deletion: {}
+
+    - name: verify-project-gone-from-main-cluster
+      description: Verify the Project no longer exists in the main cluster
+      cluster: main
+      try:
+        - error:
+            resource:
+              apiVersion: resourcemanager.miloapis.com/v1alpha1
+              kind: Project
+              metadata:
+                name: project-lifecycle-test
+            timeout: 30s

--- a/test/resource-management/project-lifecycle/kubeconfig-main
+++ b/test/resource-management/project-lifecycle/kubeconfig-main
@@ -1,0 +1,18 @@
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://localhost:30443
+  name: milo-main
+contexts:
+- context:
+    cluster: milo-main
+    user: test-admin
+  name: milo-main
+current-context: milo-main
+kind: Config
+preferences: {}
+users:
+- name: test-admin
+  user:
+    token: test-admin-token

--- a/test/resource-management/project-lifecycle/kubeconfig-org-template
+++ b/test/resource-management/project-lifecycle/kubeconfig-org-template
@@ -1,0 +1,18 @@
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://localhost:30443/apis/resourcemanager.miloapis.com/v1alpha1/organizations/test-project-lifecycle-org/control-plane
+  name: org-test-project-lifecycle-org
+contexts:
+- context:
+    cluster: org-test-project-lifecycle-org
+    user: user-admin
+  name: org-test-project-lifecycle-org
+current-context: org-test-project-lifecycle-org
+kind: Config
+preferences: {}
+users:
+- name: user-admin
+  user:
+    token: test-admin-token


### PR DESCRIPTION
> **WIP / DRAFT.** Migration in progress, do not merge yet.

## What

Migrates the **Project lifecycle** Chainsaw test out of `datum-cloud/infra` into milo's local-env harness at `test/resource-management/project-lifecycle/`.

Flow:

1. Create `Organization`, `User`, and `OrganizationMembership`.
2. Create a `Project` in the org control plane and wait for `Ready`.
3. Assert it is listed in both the org and main control planes.
4. Delete it and assert it is gone.

## Why

Per `datum-cloud/infra#3006`, infra's live-env Chainsaw suite is being consolidated into a single "construct" group and single-service API-contract tests are being evacuated to their owning repos, run against milo's **local** apiserver pre-merge. This test validates the `resourcemanager.miloapis.com` Project contract, which milo owns.

The infra original was permanently `skip: true` (blocked on CI SA identity resolution and `User.iam.miloapis.com` uid, infra#2733) and depended on `datumctl` live-auth. Running it here against the local apiserver removes both blockers.

Refs:
- `datum-cloud/infra#3006` (consolidation / evacuation)
- `datum-cloud/infra#3005`

## Adaptation from the infra original

- Dropped `datumctl auth update-kubeconfig` steps and the live-auth `clusters:`/`cluster:` kubeconfig plumbing; targets local `main` and `org` control planes using the sibling `project-creation` kubeconfig convention.
- Removed `spec.skip: true`.
- Added Organization, User, and OrganizationMembership fixtures (the local apiserver requires these before a Project can be created in the org CP).
- Added a `spec.description` block; zero inline comments per repo convention.

`chainsaw lint`: passes.

## Known-uncertain

- Ready-status timing (`Ready=True` within 60s) mirrors the sibling `project-creation` and `project-deletion` tests, but was not executed end-to-end in this branch (no live green CI run performed, do not block on CI here).
- The `assert-project-ready.yaml` status block (`reason: Ready`, `message: Project is ready`) is copied from the sibling assertion. If the local reconciler emits different reason or message text the assert may need loosening.
