### PR TITLE
test: migrate project-namespace-init from infra (WIP)

### DIFF
--- a/test/resource-management/project-namespace-init/01-test-organization.yaml
+++ b/test/resource-management/project-namespace-init/01-test-organization.yaml
@@ -1,0 +1,11 @@
+apiVersion: resourcemanager.miloapis.com/v1alpha1
+kind: Organization
+metadata:
+  name: test-project-namespace-init-org
+  labels:
+    test.miloapis.com/scenario: "project-namespace-init"
+  annotations:
+    kubernetes.io/description: "Organization for testing project namespace init"
+    kubernetes.io/display-name: "Test Project Namespace Init Organization"
+spec:
+  type: Standard

--- a/test/resource-management/project-namespace-init/02-test-user.yaml
+++ b/test/resource-management/project-namespace-init/02-test-user.yaml
@@ -1,0 +1,10 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: User
+metadata:
+  name: user-admin
+  labels:
+    test.miloapis.com/scenario: "project-namespace-init"
+spec:
+  email: admin@test.local
+  givenName: ProjectTest
+  familyName: Admin

--- a/test/resource-management/project-namespace-init/03-organization-membership.yaml
+++ b/test/resource-management/project-namespace-init/03-organization-membership.yaml
@@ -1,0 +1,12 @@
+apiVersion: resourcemanager.miloapis.com/v1alpha1
+kind: OrganizationMembership
+metadata:
+  name: user-admin-membership
+  namespace: organization-test-project-namespace-init-org
+  labels:
+    test.miloapis.com/scenario: "project-namespace-init"
+spec:
+  organizationRef:
+    name: test-project-namespace-init-org
+  userRef:
+    name: "user-admin"

--- a/test/resource-management/project-namespace-init/04-test-project.yaml
+++ b/test/resource-management/project-namespace-init/04-test-project.yaml
@@ -1,0 +1,10 @@
+apiVersion: resourcemanager.miloapis.com/v1alpha1
+kind: Project
+metadata:
+  name: project-namespace-init-test
+  labels:
+    test.miloapis.com/scenario: "project-namespace-init"
+spec:
+  ownerRef:
+    kind: Organization
+    name: test-project-namespace-init-org

--- a/test/resource-management/project-namespace-init/chainsaw-test.yaml
+++ b/test/resource-management/project-namespace-init/chainsaw-test.yaml
@@ -1,0 +1,112 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: project-namespace-init
+spec:
+  description: |
+    Tests that a newly created Project has its control plane provisioned with
+    a default namespace that can immediately serve resources.
+
+    This test verifies:
+    - A Project can be created in an Organization control plane and reaches
+      Ready status
+    - The Project control plane serves a default namespace once provisioned
+    - Basic namespaced resources (ConfigMap, Secret) can be created in the
+      default namespace of the Project control plane
+
+    Migrated from datum-cloud/infra (infra#3006). The original ran against a
+    live environment via datumctl auth; this variant reaches the org and
+    project control planes served by the local Milo apiserver directly.
+
+  clusters:
+    main:
+      kubeconfig: kubeconfig-main
+    org:
+      kubeconfig: kubeconfig-org-template
+    project:
+      kubeconfig: kubeconfig-project-template
+
+  steps:
+    - name: setup-organization
+      description: Create Organization, User, and OrganizationMembership for project testing
+      try:
+        - apply:
+            file: 01-test-organization.yaml
+        - wait:
+            apiVersion: v1
+            kind: Namespace
+            name: organization-test-project-namespace-init-org
+            timeout: 30s
+            for:
+              jsonPath:
+                path: '{.status.phase}'
+                value: Active
+        - apply:
+            file: 02-test-user.yaml
+        - wait:
+            apiVersion: iam.miloapis.com/v1alpha1
+            kind: User
+            name: "user-admin"
+            timeout: 30s
+            for:
+              condition:
+                name: Ready
+                value: 'True'
+        - apply:
+            file: 03-organization-membership.yaml
+
+    - name: create-project-and-wait-for-ready
+      description: Create Project in organization context and verify it reaches Ready status
+      cluster: org
+      try:
+        - apply:
+            file: 04-test-project.yaml
+        - wait:
+            apiVersion: resourcemanager.miloapis.com/v1alpha1
+            kind: Project
+            name: project-namespace-init-test
+            timeout: 60s
+            for:
+              condition:
+                name: Ready
+                value: 'True'
+
+    - name: verify-default-namespace-provisioned
+      description: Verify the Project control plane serves the default namespace
+      cluster: project
+      try:
+        - wait:
+            apiVersion: v1
+            kind: Namespace
+            name: default
+            timeout: 60s
+            for:
+              jsonPath:
+                path: '{.status.phase}'
+                value: Active
+
+    - name: create-resources-in-project
+      description: Verify basic resources can be created in the Project default namespace
+      cluster: project
+      try:
+        - apply:
+            file: test-data/configmap.yaml
+        - assert:
+            resource:
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: test-configmap
+                namespace: default
+              data:
+                key: value
+        - apply:
+            file: test-data/secret.yaml
+        - assert:
+            resource:
+              apiVersion: v1
+              kind: Secret
+              metadata:
+                name: test-secret
+                namespace: default
+              type: Opaque

--- a/test/resource-management/project-namespace-init/kubeconfig-main
+++ b/test/resource-management/project-namespace-init/kubeconfig-main
@@ -1,0 +1,18 @@
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://localhost:30443
+  name: milo-main
+contexts:
+- context:
+    cluster: milo-main
+    user: test-admin
+  name: milo-main
+current-context: milo-main
+kind: Config
+preferences: {}
+users:
+- name: test-admin
+  user:
+    token: test-admin-token

--- a/test/resource-management/project-namespace-init/kubeconfig-org-template
+++ b/test/resource-management/project-namespace-init/kubeconfig-org-template
@@ -1,0 +1,18 @@
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://localhost:30443/apis/resourcemanager.miloapis.com/v1alpha1/organizations/test-project-namespace-init-org/control-plane
+  name: org-test-project-namespace-init-org
+contexts:
+- context:
+    cluster: org-test-project-namespace-init-org
+    user: user-admin
+  name: org-test-project-namespace-init-org
+current-context: org-test-project-namespace-init-org
+kind: Config
+preferences: {}
+users:
+- name: user-admin
+  user:
+    token: test-admin-token

--- a/test/resource-management/project-namespace-init/kubeconfig-project-template
+++ b/test/resource-management/project-namespace-init/kubeconfig-project-template
@@ -1,0 +1,18 @@
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://localhost:30443/apis/resourcemanager.miloapis.com/v1alpha1/projects/project-namespace-init-test/control-plane
+  name: project-namespace-init-test
+contexts:
+- context:
+    cluster: project-namespace-init-test
+    user: user-admin
+  name: project-namespace-init-test
+current-context: project-namespace-init-test
+kind: Config
+preferences: {}
+users:
+- name: user-admin
+  user:
+    token: test-admin-token

--- a/test/resource-management/project-namespace-init/test-data/configmap.yaml
+++ b/test/resource-management/project-namespace-init/test-data/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-configmap
+  namespace: default
+  labels:
+    test.miloapis.com/scenario: "project-namespace-init"
+data:
+  key: value

--- a/test/resource-management/project-namespace-init/test-data/secret.yaml
+++ b/test/resource-management/project-namespace-init/test-data/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secret
+  namespace: default
+  labels:
+    test.miloapis.com/scenario: "project-namespace-init"
+type: Opaque
+stringData:
+  key: secret-value


### PR DESCRIPTION
> **WIP / DRAFT.** Migration in progress, do not merge yet.

## What

Migrates the **Project namespace-init** Chainsaw test out of `datum-cloud/infra` into milo's local-env harness at `test/resource-management/project-namespace-init/`.

Flow:

1. Create `Organization`, `User`, and `OrganizationMembership`.
2. Create a `Project` in the org control plane and wait for `Ready`.
3. Switch to the **project control plane** and assert the `default` namespace is `Active`.
4. Create and assert a `ConfigMap` and a `Secret` in it.

## Why

Per `datum-cloud/infra#3006`, single-service API-contract tests are being evacuated from infra's live-env suite to their owning repos and run against milo's **local** apiserver pre-merge. This validates the `resourcemanager.miloapis.com` project-control-plane provisioning contract, which milo owns.

The infra original was permanently `skip: true` and depended on `datumctl` live-auth for both the org and project control planes.

Refs:
- `datum-cloud/infra#3006` (consolidation / evacuation)
- `datum-cloud/infra#3005`

## Adaptation from the infra original

- Dropped both `datumctl auth update-kubeconfig` steps (org CP and project CP) and the live-auth kubeconfig plumbing.
- Reaches the **project control plane** directly via the local apiserver URL-path subresource `.../v1alpha1/projects/<project>/control-plane`, matching the existing `quota/multi-cluster-enforcement` test which already provisions a project CP and writes a Secret to its `default` namespace.
- Removed `spec.skip: true`; added Organization, User, and OrganizationMembership fixtures; added a `spec.description`; zero inline comments per repo convention.

`chainsaw lint`: passes.

## Known-uncertain

**The local env DOES provision project control planes.** Confirmed: `test/quota/multi-cluster-enforcement` already creates a Project in the org CP, then targets `.../projects/<name>/control-plane` and creates a `Secret` in its `default` namespace. So this test was ported at full fidelity (default-namespace assertion plus ConfigMap and Secret), not degraded.

Remaining uncertainty:
- Timings (`Ready` 60s, `default` namespace `Active` 60s) mirror sibling tests but were not executed end-to-end in this branch (no live CI run performed, do not block on CI here).
- If the project CP provisions `default` lazily or more slowly than the org namespace, the 60s wait on the namespace may need bumping.
