### PR TITLE
test(e2e): Add ServiceAccount API contract test

### DIFF
--- a/test/iam/service-account-contract/01-test-organization.yaml
+++ b/test/iam/service-account-contract/01-test-organization.yaml
@@ -1,0 +1,11 @@
+apiVersion: resourcemanager.miloapis.com/v1alpha1
+kind: Organization
+metadata:
+  name: test-service-account-contract-org
+  labels:
+    test.miloapis.com/scenario: "service-account-contract"
+  annotations:
+    kubernetes.io/description: "Organization for testing the ServiceAccount API contract"
+    kubernetes.io/display-name: "Test Service Account Contract Organization"
+spec:
+  type: Standard

--- a/test/iam/service-account-contract/02-test-user.yaml
+++ b/test/iam/service-account-contract/02-test-user.yaml
@@ -1,0 +1,10 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: User
+metadata:
+  name: user-admin
+  labels:
+    test.miloapis.com/scenario: "service-account-contract"
+spec:
+  email: admin@test.local
+  givenName: ServiceAccountTest
+  familyName: Admin

--- a/test/iam/service-account-contract/02-test-user.yaml
+++ b/test/iam/service-account-contract/02-test-user.yaml
@@ -1,0 +1,10 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: User
+metadata:
+  name: user-service-account-contract
+  labels:
+    test.miloapis.com/scenario: "service-account-contract"
+spec:
+  email: service-account-contract-admin@test.local
+  givenName: ServiceAccountTest
+  familyName: Admin

--- a/test/iam/service-account-contract/03-organization-membership.yaml
+++ b/test/iam/service-account-contract/03-organization-membership.yaml
@@ -1,0 +1,12 @@
+apiVersion: resourcemanager.miloapis.com/v1alpha1
+kind: OrganizationMembership
+metadata:
+  name: user-admin-membership
+  namespace: organization-test-service-account-contract-org
+  labels:
+    test.miloapis.com/scenario: "service-account-contract"
+spec:
+  organizationRef:
+    name: test-service-account-contract-org
+  userRef:
+    name: "user-admin"

--- a/test/iam/service-account-contract/03-organization-membership.yaml
+++ b/test/iam/service-account-contract/03-organization-membership.yaml
@@ -1,0 +1,12 @@
+apiVersion: resourcemanager.miloapis.com/v1alpha1
+kind: OrganizationMembership
+metadata:
+  name: user-service-account-contract-membership
+  namespace: organization-test-service-account-contract-org
+  labels:
+    test.miloapis.com/scenario: "service-account-contract"
+spec:
+  organizationRef:
+    name: test-service-account-contract-org
+  userRef:
+    name: "user-service-account-contract"

--- a/test/iam/service-account-contract/04-test-project.yaml
+++ b/test/iam/service-account-contract/04-test-project.yaml
@@ -1,0 +1,10 @@
+apiVersion: resourcemanager.miloapis.com/v1alpha1
+kind: Project
+metadata:
+  name: service-account-contract-test
+  labels:
+    test.miloapis.com/scenario: "service-account-contract"
+spec:
+  ownerRef:
+    kind: Organization
+    name: test-service-account-contract-org

--- a/test/iam/service-account-contract/README.md
+++ b/test/iam/service-account-contract/README.md
@@ -1,0 +1,72 @@
+# Test: `service-account-contract`
+
+Tests the iam.miloapis.com ServiceAccount API contract in a Project
+control plane served by the local Milo apiserver.
+
+This test verifies:
+- A ServiceAccount can be created in a Project control plane
+- spec.state defaults to Active when spec.state is omitted
+- A ServiceAccount can be deleted and is fully removed
+
+Key issuance, authentication, and revocation for service accounts need
+the auth service, which the local env lacks, so they are not covered
+here.
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [setup-organization](#step-setup-organization) | 0 | 5 | 0 | 0 | 0 |
+| 2 | [create-project-and-wait-for-ready](#step-create-project-and-wait-for-ready) | 0 | 2 | 0 | 0 | 0 |
+| 3 | [create-service-account](#step-create-service-account) | 0 | 2 | 0 | 0 | 0 |
+| 4 | [delete-service-account](#step-delete-service-account) | 0 | 2 | 0 | 0 | 0 |
+
+### Step: `setup-organization`
+
+Create Organization, User, and OrganizationMembership for the project
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `wait` | 0 | 0 | *No description* |
+| 3 | `apply` | 0 | 0 | *No description* |
+| 4 | `wait` | 0 | 0 | *No description* |
+| 5 | `apply` | 0 | 0 | *No description* |
+
+### Step: `create-project-and-wait-for-ready`
+
+Create the Project that hosts the ServiceAccount control plane
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `wait` | 0 | 0 | *No description* |
+
+### Step: `create-service-account`
+
+Create a ServiceAccount in the Project control plane and verify spec.state defaults to Active
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `delete-service-account`
+
+Delete the ServiceAccount and verify it is removed
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `delete` | 0 | 0 | *No description* |
+| 2 | `error` | 0 | 0 | *No description* |
+
+---

--- a/test/iam/service-account-contract/README.md
+++ b/test/iam/service-account-contract/README.md
@@ -5,11 +5,14 @@ control plane served by the local Milo apiserver.
 
 This test verifies:
 - A ServiceAccount can be created in a Project control plane
-- spec.state defaults to Active when spec.state is omitted
+- spec.state defaults to Active when spec is present and spec.state is
+  omitted
+- The ServiceAccount is not visible at the platform root, so it is
+  scoped to the Project control plane
 - A ServiceAccount can be deleted and is fully removed
 
 Key issuance, authentication, and revocation for service accounts need
-the auth service, which the local env lacks, so they are not covered
+the auth service, which the local environment lacks, so they are not covered
 here.
 
 
@@ -20,7 +23,8 @@ here.
 | 1 | [setup-organization](#step-setup-organization) | 0 | 5 | 0 | 0 | 0 |
 | 2 | [create-project-and-wait-for-ready](#step-create-project-and-wait-for-ready) | 0 | 2 | 0 | 0 | 0 |
 | 3 | [create-service-account](#step-create-service-account) | 0 | 2 | 0 | 0 | 0 |
-| 4 | [delete-service-account](#step-delete-service-account) | 0 | 2 | 0 | 0 | 0 |
+| 4 | [verify-service-account-absent-at-root](#step-verify-service-account-absent-at-root) | 0 | 1 | 0 | 0 | 0 |
+| 5 | [delete-service-account](#step-delete-service-account) | 0 | 2 | 0 | 0 | 0 |
 
 ### Step: `setup-organization`
 
@@ -57,6 +61,16 @@ Create a ServiceAccount in the Project control plane and verify spec.state defau
 |:-:|---|:-:|:-:|---|
 | 1 | `apply` | 0 | 0 | *No description* |
 | 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `verify-service-account-absent-at-root`
+
+Verify the ServiceAccount is not stored at the platform root
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `error` | 0 | 0 | *No description* |
 
 ### Step: `delete-service-account`
 

--- a/test/iam/service-account-contract/chainsaw-test.yaml
+++ b/test/iam/service-account-contract/chainsaw-test.yaml
@@ -1,0 +1,107 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: service-account-contract
+spec:
+  description: |
+    Tests the iam.miloapis.com ServiceAccount API contract against a Project
+    control plane served by the local Milo apiserver.
+
+    This test verifies:
+    - A ServiceAccount can be created in a Project control plane
+    - spec.state defaults to Active
+    - A ServiceAccount can be deleted and is fully removed
+
+    Migrated from datum-cloud/infra (infra#3006). This is a deliberately thin
+    rewrite of the infra service-account-lifecycle test. The original also
+    exercised datumctl-driven key issuance, authentication as the service
+    account, and key revocation, which require the auth service (Zitadel) that
+    is absent in the local env. That key-issuance/auth/revoke roundtrip
+    intentionally REMAINS an infra "construct" test (still skipped until
+    datumctl gains the commands), per infra#3006. Here we validate only the
+    API contract that milo itself owns and serves locally.
+
+  clusters:
+    main:
+      kubeconfig: kubeconfig-main
+    org:
+      kubeconfig: kubeconfig-org-template
+    project:
+      kubeconfig: kubeconfig-project-template
+
+  steps:
+    - name: setup-organization
+      description: Create Organization, User, and OrganizationMembership for the project
+      try:
+        - apply:
+            file: 01-test-organization.yaml
+        - wait:
+            apiVersion: v1
+            kind: Namespace
+            name: organization-test-service-account-contract-org
+            timeout: 30s
+            for:
+              jsonPath:
+                path: '{.status.phase}'
+                value: Active
+        - apply:
+            file: 02-test-user.yaml
+        - wait:
+            apiVersion: iam.miloapis.com/v1alpha1
+            kind: User
+            name: "user-admin"
+            timeout: 30s
+            for:
+              condition:
+                name: Ready
+                value: 'True'
+        - apply:
+            file: 03-organization-membership.yaml
+
+    - name: create-project-and-wait-for-ready
+      description: Create the Project that hosts the ServiceAccount control plane
+      cluster: org
+      try:
+        - apply:
+            file: 04-test-project.yaml
+        - wait:
+            apiVersion: resourcemanager.miloapis.com/v1alpha1
+            kind: Project
+            name: service-account-contract-test
+            timeout: 60s
+            for:
+              condition:
+                name: Ready
+                value: 'True'
+
+    - name: create-service-account
+      description: Create a ServiceAccount in the Project control plane and verify spec.state defaults to Active
+      cluster: project
+      try:
+        - apply:
+            file: test-data/service-account.yaml
+        - assert:
+            resource:
+              apiVersion: iam.miloapis.com/v1alpha1
+              kind: ServiceAccount
+              metadata:
+                name: test-service-account
+              spec:
+                state: Active
+
+    - name: delete-service-account
+      description: Delete the ServiceAccount and verify it is removed
+      cluster: project
+      try:
+        - delete:
+            ref:
+              apiVersion: iam.miloapis.com/v1alpha1
+              kind: ServiceAccount
+              name: test-service-account
+        - error:
+            resource:
+              apiVersion: iam.miloapis.com/v1alpha1
+              kind: ServiceAccount
+              metadata:
+                name: test-service-account
+            timeout: 30s

--- a/test/iam/service-account-contract/chainsaw-test.yaml
+++ b/test/iam/service-account-contract/chainsaw-test.yaml
@@ -9,11 +9,14 @@ spec:
 
     This test verifies:
     - A ServiceAccount can be created in a Project control plane
-    - spec.state defaults to Active when spec.state is omitted
+    - spec.state defaults to Active when spec is present and spec.state is
+      omitted
+    - The ServiceAccount is not visible at the platform root, so it is
+      scoped to the Project control plane
     - A ServiceAccount can be deleted and is fully removed
 
     Key issuance, authentication, and revocation for service accounts need
-    the auth service, which the local env lacks, so they are not covered
+    the auth service, which the local environment lacks, so they are not covered
     here.
 
   clusters:
@@ -85,6 +88,18 @@ spec:
                 name: test-service-account
               spec:
                 state: Active
+
+    - name: verify-service-account-absent-at-root
+      description: Verify the ServiceAccount is not stored at the platform root
+      cluster: main
+      try:
+        - error:
+            timeout: 30s
+            resource:
+              apiVersion: iam.miloapis.com/v1alpha1
+              kind: ServiceAccount
+              metadata:
+                name: test-service-account
 
     - name: delete-service-account
       description: Delete the ServiceAccount and verify it is removed

--- a/test/iam/service-account-contract/chainsaw-test.yaml
+++ b/test/iam/service-account-contract/chainsaw-test.yaml
@@ -1,0 +1,104 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: service-account-contract
+spec:
+  description: |
+    Tests the iam.miloapis.com ServiceAccount API contract in a Project
+    control plane served by the local Milo apiserver.
+
+    This test verifies:
+    - A ServiceAccount can be created in a Project control plane
+    - spec.state defaults to Active when spec.state is omitted
+    - A ServiceAccount can be deleted and is fully removed
+
+    Key issuance, authentication, and revocation for service accounts need
+    the auth service, which the local env lacks, so they are not covered
+    here.
+
+  clusters:
+    main:
+      kubeconfig: kubeconfig-main
+    org:
+      kubeconfig: kubeconfig-org-template
+    project:
+      kubeconfig: kubeconfig-project
+
+  steps:
+    - name: setup-organization
+      description: Create Organization, User, and OrganizationMembership for the project
+      cluster: main
+      try:
+        - apply:
+            file: 01-test-organization.yaml
+        - wait:
+            apiVersion: v1
+            kind: Namespace
+            name: organization-test-service-account-contract-org
+            timeout: 30s
+            for:
+              jsonPath:
+                path: '{.status.phase}'
+                value: Active
+        - apply:
+            file: 02-test-user.yaml
+        - wait:
+            apiVersion: iam.miloapis.com/v1alpha1
+            kind: User
+            name: "user-service-account-contract"
+            timeout: 30s
+            for:
+              condition:
+                name: Ready
+                value: 'True'
+        - apply:
+            file: 03-organization-membership.yaml
+
+    - name: create-project-and-wait-for-ready
+      description: Create the Project that hosts the ServiceAccount control plane
+      cluster: org
+      try:
+        - apply:
+            file: 04-test-project.yaml
+        - wait:
+            apiVersion: resourcemanager.miloapis.com/v1alpha1
+            kind: Project
+            name: service-account-contract-test
+            timeout: 60s
+            for:
+              condition:
+                name: Ready
+                value: 'True'
+
+    - name: create-service-account
+      description: Create a ServiceAccount in the Project control plane and verify spec.state defaults to Active
+      cluster: project
+      try:
+        - apply:
+            file: test-data/service-account.yaml
+        - assert:
+            timeout: 30s
+            resource:
+              apiVersion: iam.miloapis.com/v1alpha1
+              kind: ServiceAccount
+              metadata:
+                name: test-service-account
+              spec:
+                state: Active
+
+    - name: delete-service-account
+      description: Delete the ServiceAccount and verify it is removed
+      cluster: project
+      try:
+        - delete:
+            ref:
+              apiVersion: iam.miloapis.com/v1alpha1
+              kind: ServiceAccount
+              name: test-service-account
+        - error:
+            resource:
+              apiVersion: iam.miloapis.com/v1alpha1
+              kind: ServiceAccount
+              metadata:
+                name: test-service-account
+            timeout: 30s

--- a/test/iam/service-account-contract/kubeconfig-main
+++ b/test/iam/service-account-contract/kubeconfig-main
@@ -1,0 +1,18 @@
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://localhost:30443
+  name: milo-main
+contexts:
+- context:
+    cluster: milo-main
+    user: test-admin
+  name: milo-main
+current-context: milo-main
+kind: Config
+preferences: {}
+users:
+- name: test-admin
+  user:
+    token: test-admin-token

--- a/test/iam/service-account-contract/kubeconfig-org-template
+++ b/test/iam/service-account-contract/kubeconfig-org-template
@@ -1,0 +1,18 @@
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://localhost:30443/apis/resourcemanager.miloapis.com/v1alpha1/organizations/test-service-account-contract-org/control-plane
+  name: org-test-service-account-contract-org
+contexts:
+- context:
+    cluster: org-test-service-account-contract-org
+    user: user-admin
+  name: org-test-service-account-contract-org
+current-context: org-test-service-account-contract-org
+kind: Config
+preferences: {}
+users:
+- name: user-admin
+  user:
+    token: test-admin-token

--- a/test/iam/service-account-contract/kubeconfig-org-template
+++ b/test/iam/service-account-contract/kubeconfig-org-template
@@ -1,0 +1,18 @@
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://localhost:30443/apis/resourcemanager.miloapis.com/v1alpha1/organizations/test-service-account-contract-org/control-plane
+  name: org-test-service-account-contract-org
+contexts:
+- context:
+    cluster: org-test-service-account-contract-org
+    user: user-service-account-contract
+  name: org-test-service-account-contract-org
+current-context: org-test-service-account-contract-org
+kind: Config
+preferences: {}
+users:
+- name: user-service-account-contract
+  user:
+    token: test-admin-token

--- a/test/iam/service-account-contract/kubeconfig-project
+++ b/test/iam/service-account-contract/kubeconfig-project
@@ -1,0 +1,18 @@
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://localhost:30443/apis/resourcemanager.miloapis.com/v1alpha1/projects/service-account-contract-test/control-plane
+  name: project-service-account-contract-test
+contexts:
+- context:
+    cluster: project-service-account-contract-test
+    user: user-service-account-contract
+  name: project-service-account-contract-test
+current-context: project-service-account-contract-test
+kind: Config
+preferences: {}
+users:
+- name: user-service-account-contract
+  user:
+    token: test-admin-token

--- a/test/iam/service-account-contract/kubeconfig-project-template
+++ b/test/iam/service-account-contract/kubeconfig-project-template
@@ -1,0 +1,18 @@
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://localhost:30443/apis/resourcemanager.miloapis.com/v1alpha1/projects/service-account-contract-test/control-plane
+  name: project-service-account-contract-test
+contexts:
+- context:
+    cluster: project-service-account-contract-test
+    user: user-admin
+  name: project-service-account-contract-test
+current-context: project-service-account-contract-test
+kind: Config
+preferences: {}
+users:
+- name: user-admin
+  user:
+    token: test-admin-token

--- a/test/iam/service-account-contract/test-data/service-account.yaml
+++ b/test/iam/service-account-contract/test-data/service-account.yaml
@@ -1,0 +1,6 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: ServiceAccount
+metadata:
+  name: test-service-account
+  labels:
+    test.miloapis.com/scenario: "service-account-contract"

--- a/test/iam/service-account-contract/test-data/service-account.yaml
+++ b/test/iam/service-account-contract/test-data/service-account.yaml
@@ -1,0 +1,7 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: ServiceAccount
+metadata:
+  name: test-service-account
+  labels:
+    test.miloapis.com/scenario: "service-account-contract"
+spec: {}


### PR DESCRIPTION
## Summary

Service accounts had no end-to-end coverage. This test creates one in a project control plane, checks that a new service account starts active, then deletes it and checks it is gone.

Key issuance, authentication, and revocation need the auth service, which the local env lacks, so they stay in infra.

## Test plan

- [ ] The e2e suite passes with the new service account coverage

Related to datum-cloud/infra#3006.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZxVq7kz9bNaDyvSxWPm4c