### PR TITLE
fix: run controller-manager with 2 replicas for webhook HA

### DIFF
--- a/cmd/milo/controller-manager/webhooks.go
+++ b/cmd/milo/controller-manager/webhooks.go
@@ -160,6 +160,12 @@ func newWebhookRESTMapper(ctx context.Context, rootClientBuilder clientbuilder.C
 // startCoreControlPlaneWebhooks starts the admission webhook server on every replica.
 // It is invoked before leader election when leader election is enabled so followers
 // also listen on the webhook port and Service endpoints remain healthy.
+//
+// This is the dedicated, non-leader-election webhook manager: admission stays
+// available even when leadership has not been (or cannot be) acquired, so it is
+// independent of the leader-gated reconcile loops. Do NOT add a separate webhook
+// Deployment to "decouple" it — that is already done here. To harden webhook
+// availability, run the controller-manager with >=2 replicas.
 func startCoreControlPlaneWebhooks(
 	ctx context.Context,
 	opts *Options,

--- a/cmd/milo/controller-manager/webhooks.go
+++ b/cmd/milo/controller-manager/webhooks.go
@@ -165,6 +165,12 @@ func newWebhookRESTMapper(ctx context.Context, rootClientBuilder clientbuilder.C
 // startCoreControlPlaneWebhooks starts the admission webhook server on every replica.
 // It is invoked before leader election when leader election is enabled so followers
 // also listen on the webhook port and Service endpoints remain healthy.
+//
+// This is the dedicated, non-leader-election webhook manager: admission stays
+// available even when leadership has not been (or cannot be) acquired, so it is
+// independent of the leader-gated reconcile loops. Do NOT add a separate webhook
+// Deployment to "decouple" it — that is already done here. To harden webhook
+// availability, run the controller-manager with >=2 replicas.
 func startCoreControlPlaneWebhooks(
 	ctx context.Context,
 	opts *Options,

--- a/config/controller-manager/base/deployment.yaml
+++ b/config/controller-manager/base/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: milo-controller-manager
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app.kubernetes.io/name: milo-controller-manager


### PR DESCRIPTION
## What

Run `milo-controller-manager` with **2 replicas** so admission webhooks stay available across a pod outage.

Implements datum-cloud/infra#2365 ("Run milo-controller-manager in HA mode (2 replicas)").

## Why

Admission webhooks already start on **every** replica via the dedicated non-leader-election webhook manager (`startCoreControlPlaneWebhooks`). They serve before and independent of leader election. The prerequisite fix for that (webhook only started on the elected leader) landed in `main` via #9ffd87f, #c179dbf, and #08c4dae (tracked as #684). A separate webhook Deployment is **not** needed to decouple webhook availability from leadership.

The one remaining gap behind the bootstrap boot loop (datum-cloud/infra#1526, milo#716) was that the controller-manager ran a **single** replica (`replicas: 1`), so admission still died whenever that pod did (crashloop, OOM #631, rollout). With one replica the all-replica webhook code has no other replica to fall back to.

## How

- `config/controller-manager/base/deployment.yaml`: `replicas: 1` becomes `2`.
- Document the invariant at `startCoreControlPlaneWebhooks` so future work doesn't reintroduce a separate webhook Deployment to solve availability.

## Notes

- Multi-replica is safe now: the webhook server listens on all replicas (#684), not just the leader; reconcile loops remain leader-gated.
- milo#389 (leader election hardcodes `datum-system`) is a cross-namespace collision bug, not a same-namespace replica-count blocker. The deployment already passes `--leader-elect-resource-namespace=milo-system`.
- Supersedes the separate-webhook-Deployment approach earlier in this PR (per review feedback); milo#716 closed in favour of infra#2365.
