### PR TITLE
Repair OpenAPI definition names for the identity group

### DIFF
--- a/cmd/milo/apiserver/config.go
+++ b/cmd/milo/apiserver/config.go
@@ -3,6 +3,7 @@ package app
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -63,6 +64,8 @@ import (
 	datumfilters "go.miloapis.com/milo/pkg/server/filters"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	openapicommon "k8s.io/kube-openapi/pkg/common"
+	openapiutil "k8s.io/kube-openapi/pkg/util"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 type Config struct {
@@ -344,6 +347,39 @@ func (c *Config) Complete() (CompletedConfig, error) {
 	}}, nil
 }
 
+// restFriendlyDefinitionNames converts OpenAPI definition names that still carry
+// a raw Go import path before handing them to the generic namer.
+//
+// The identity types are produced by a pinned openapi-gen (see the
+// generate:openapi:identity task) that predates the Kubernetes 1.35 convention
+// of emitting REST-friendly model names. Through 1.34 the serving layer applied
+// that conversion itself; 1.35 moved it into the generator and turned
+// DefinitionNamer.GetDefinitionName into a pass-through, so the import path now
+// reaches the published spec verbatim. Its slashes are JSON-Pointer escaped to
+// "~1" inside every $ref while the definitions key keeps the literal "/", which
+// leaves every intra-group reference dangling and breaks client-side validation
+// for every group this apiserver serves, not just identity.
+//
+// Converting before the namer runs also lets its lookup hit, which restores the
+// x-kubernetes-group-version-kind extension on the identity kinds.
+//
+// Only slash-bearing names are converted: ToRESTFriendlyName is not idempotent
+// and would mangle an already-friendly "io.k8s.api.core.v1.Pod" into
+// "Pod.v1.core.api.k8s.io".
+//
+// Drop this once the identity types are regenerated with a 1.35-era openapi-gen.
+func restFriendlyDefinitionNames(namer func(string) (string, spec.Extensions)) func(string) (string, spec.Extensions) {
+	return func(name string) (string, spec.Extensions) {
+		if strings.Contains(name, "/") {
+			name = openapiutil.ToRESTFriendlyName(name)
+		}
+		if namer == nil {
+			return name, nil
+		}
+		return namer(name)
+	}
+}
+
 func NewConfig(opts options.CompletedOptions) (*Config, error) {
 	var registry *discoveryctx.Registry
 	if utilfeature.DefaultFeatureGate.Enabled(features.DiscoveryContextFilter) {
@@ -400,6 +436,13 @@ func NewConfig(opts options.CompletedOptions) (*Config, error) {
 	)
 	if err != nil {
 		return nil, err
+	}
+
+	if genericConfig.OpenAPIConfig != nil {
+		genericConfig.OpenAPIConfig.GetDefinitionName = restFriendlyDefinitionNames(genericConfig.OpenAPIConfig.GetDefinitionName)
+	}
+	if genericConfig.OpenAPIV3Config != nil {
+		genericConfig.OpenAPIV3Config.GetDefinitionName = restFriendlyDefinitionNames(genericConfig.OpenAPIV3Config.GetDefinitionName)
 	}
 
 	loopbackClientConfig := genericConfig.LoopbackClientConfig

--- a/cmd/milo/apiserver/openapi_test.go
+++ b/cmd/milo/apiserver/openapi_test.go
@@ -1,0 +1,74 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	identityopenapi "go.miloapis.com/milo/pkg/apis/identity/v1alpha1"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+// passthroughNamer mimics DefinitionNamer.GetDefinitionName as of Kubernetes
+// 1.35, which returns the generated name verbatim.
+func passthroughNamer(name string) (string, spec.Extensions) { return name, nil }
+
+func TestRestFriendlyDefinitionNames(t *testing.T) {
+	namer := restFriendlyDefinitionNames(passthroughNamer)
+
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "go import path is converted",
+			in:   "go.miloapis.com/milo/pkg/apis/identity/v1alpha1.Passkey",
+			want: "com.miloapis.go.milo.pkg.apis.identity.v1alpha1.Passkey",
+		},
+		{
+			// ToRESTFriendlyName is not idempotent, so an already-friendly name
+			// must be left untouched rather than reversed a second time.
+			name: "already friendly name is untouched",
+			in:   "io.k8s.api.core.v1.Pod",
+			want: "io.k8s.api.core.v1.Pod",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, _ := namer(tc.in); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// A definition name containing a slash is JSON-Pointer escaped to "~1" inside
+// every $ref while the definitions key keeps the literal slash, which leaves the
+// reference dangling and breaks client-side validation for every group this
+// apiserver serves.
+func TestIdentityDefinitionNamesCarryNoSlashes(t *testing.T) {
+	namer := restFriendlyDefinitionNames(passthroughNamer)
+
+	for name := range identityopenapi.GetOpenAPIDefinitions(spec.MustCreateRef) {
+		served, _ := namer(name)
+		if strings.Contains(served, "/") {
+			t.Errorf("definition %q is served as %q, which contains a slash", name, served)
+		}
+	}
+}
+
+// Every type an identity definition depends on must itself be published, or the
+// $ref pointing at it resolves to nothing.
+func TestIdentityOpenAPIDefinitionsHaveNoDanglingDependencies(t *testing.T) {
+	definitions := identityopenapi.GetOpenAPIDefinitions(spec.MustCreateRef)
+
+	for name, definition := range definitions {
+		for _, dependency := range definition.Dependencies {
+			if !strings.HasPrefix(dependency, "go.miloapis.com/") {
+				continue // published by the upstream Kubernetes definitions
+			}
+			if _, ok := definitions[dependency]; !ok {
+				t.Errorf("definition %q depends on %q, which is not published", name, dependency)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What

Convert slash-bearing OpenAPI definition names before handing them to the generic
namer, on both the v2 and v3 configs. Adds guard tests.

## Why

The identity types are generated by a pinned `openapi-gen` (v0.23.0, `Taskfile.yaml:346`)
that predates the Kubernetes 1.35 convention of emitting REST-friendly model names, so
it emits raw Go import paths as definition keys. Through 1.34 the serving layer applied
that conversion itself; 1.35 moved it into the generator and turned
`DefinitionNamer.GetDefinitionName` into a pass-through, so the import path now reaches
the published spec verbatim.

Its slashes are JSON-Pointer escaped to `~1` inside every `$ref` while the definitions
key keeps the literal `/`, leaving all 9 intra-group references dangling. That poisons
the whole `/openapi/v2` document, so any client doing client-side schema validation
fails on resources with nothing to do with identity — this surfaced as
network-services-operator's Federated E2E failing to apply an **IPAM** fixture:

```
error validating "test/e2e/fixtures/ipam/project-alpha/classes.yaml":
  SchemaError(go.miloapis.com/milo/pkg/apis/identity/v1alpha1.Passkey.status):
  unknown model in reference: "go.miloapis.com~1milo~1pkg~1apis~1identity~1v1alpha1.PasskeyStatus"
```

Passkey is only the alphabetically first casualty — all 13 identity definitions are
affected, `ServiceAccountKey`, `Session` and `UserIdentity` included. It has hit NSO
`main` twice ([32896926505](https://github.com/datum-cloud/network-services-operator/actions/runs/32896926505),
[32959526255](https://github.com/datum-cloud/network-services-operator/actions/runs/32959526255));
it only looks flaky because kubectl does not always take the client-side validation path.

Two details worth review attention:

- The conversion runs **before** the namer rather than after, which lets the namer's
  lookup hit and restores the `x-kubernetes-group-version-kind` extension the identity
  kinds were silently losing.
- Only slash-bearing names are converted. `ToRESTFriendlyName` is not idempotent and
  would otherwise mangle `io.k8s.api.core.v1.Pod` into `Pod.v1.core.api.k8s.io`.

This is a stopgap so the shared e2e stops breaking. The real fix is regenerating with a
1.35-era `openapi-gen` (now at `k8s.io/kube-openapi/cmd/openapi-gen`, needs
`+k8s:openapi-model-package` and `--output-model-name-file`). I trial-ran it: it produces
byte-identical names, so that follow-up is a no-op on the wire and the override can be
deleted in the same change.

## Test plan

- [x] `go build ./...`
- [x] `go test ./cmd/milo/apiserver/`
- [x] Guard tests verified to fail without the fix — all 13 identity definitions reported
- [ ] Cut a Milo release and bump the `milo-kustomize` pin in NSO (`config/dependencies/milo/`,
      currently `v0.32.5`) to confirm Federated E2E goes green

https://claude.ai/code/session_01GJXyxySyTN3vmkeFs1HMoL
