### PR TITLE
fix(build): serve a parseable version from /version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -60,3 +60,8 @@ Thumbs.db
 # Build artifacts and caches
 node_modules/
 *.log
+
+# Local vendor directory (gitignored, so CI never has one). Copying a stale
+# vendor tree into the build context breaks `go build` with "inconsistent
+# vendoring".
+vendor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,13 +23,52 @@ COPY . .
 # Build the application with optimizations and version information
 # -ldflags="-w -s" strips debug info, reducing binary size by ~30%
 # -trimpath removes file system paths from the binary for reproducible builds
-# Version information is injected via ldflags into k8s.io/component-base/version
+#
+# Version information is injected via ldflags into both
+# k8s.io/component-base/version (what the API server serves on /version) and
+# go.miloapis.com/milo/pkg/version (the Milo release, shown by `milo version`).
+#
+# The value served as gitVersion MUST parse as a semantic version: kubectl and
+# datumctl run ParseSemantic on it, and the API server itself derives its
+# feature-gate binary version from it. Milo's own release tags carry major
+# version 0 (v0.32.5), which would make the derived emulation version fail
+# ComponentGlobalsRegistry validation, so gitVersion reports the Kubernetes API
+# level this build implements and carries the Milo release in the pre-release
+# segment:
+#
+#   v1.<k8s-minor>.<k8s-patch>-milo.<milo-version>+<git-commit>
+#
+# The Kubernetes level is derived from the k8s.io/component-base requirement in
+# go.mod so it cannot drift from the vendored libraries.
 ARG VERSION=v0.0.0-master+dev
 ARG GIT_COMMIT=unknown
 ARG GIT_TREE_STATE=dirty
 ARG BUILD_DATE=unknown
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
-    go build -trimpath -o milo ./cmd/milo
+RUN set -eu; \
+    KUBE_MOD="$(awk '$1 == "k8s.io/component-base" { print $2; exit }' go.mod)"; \
+    KUBE_MOD="${KUBE_MOD#v}"; \
+    KUBE_MINOR="$(printf '%s' "${KUBE_MOD}" | cut -d. -f2)"; \
+    KUBE_PATCH="$(printf '%s' "${KUBE_MOD}" | cut -d. -f3 | cut -d- -f1)"; \
+    MILO_ID="${VERSION#v}"; \
+    MILO_ID="${MILO_ID%%+*}"; \
+    MILO_ID="$(printf '%s' "${MILO_ID}" | tr -c '0-9A-Za-z.-' '-' | sed -e 's/\.\{2,\}/./g' -e 's/^[.-]*//' -e 's/[.-]*$//')"; \
+    [ -n "${MILO_ID}" ] || MILO_ID="dev"; \
+    GIT_VERSION="v1.${KUBE_MINOR}.${KUBE_PATCH}-milo.${MILO_ID}+${GIT_COMMIT}"; \
+    echo "Building milo ${VERSION} (serving gitVersion ${GIT_VERSION})"; \
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
+    go build -trimpath -o milo \
+      -ldflags="-w -s \
+        -X k8s.io/component-base/version.gitVersion=${GIT_VERSION} \
+        -X k8s.io/component-base/version.gitMajor=1 \
+        -X k8s.io/component-base/version.gitMinor=${KUBE_MINOR} \
+        -X k8s.io/component-base/version.gitCommit=${GIT_COMMIT} \
+        -X k8s.io/component-base/version.gitTreeState=${GIT_TREE_STATE} \
+        -X k8s.io/component-base/version.buildDate=${BUILD_DATE} \
+        -X go.miloapis.com/milo/pkg/version.version=${VERSION} \
+        -X go.miloapis.com/milo/pkg/version.gitCommit=${GIT_COMMIT} \
+        -X go.miloapis.com/milo/pkg/version.gitTreeState=${GIT_TREE_STATE} \
+        -X go.miloapis.com/milo/pkg/version.buildDate=${BUILD_DATE}" \
+      ./cmd/milo
 
 # Final stage: minimal runtime image
 FROM gcr.io/distroless/static

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -49,7 +49,11 @@ tasks:
 
         # Get git information for version injection
         GIT_COMMIT=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
-        VERSION="v0.0.0-master+${GIT_COMMIT:0:7}"
+        VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "")
+        case "${VERSION}" in
+          v*) ;;
+          *) VERSION="v0.0.0-dev+${GIT_COMMIT:0:7}" ;;
+        esac
         GIT_TREE_STATE="clean"
         if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
           GIT_TREE_STATE="dirty"

--- a/cmd/milo/version/version.go
+++ b/cmd/milo/version/version.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"k8s.io/component-base/version"
 	"sigs.k8s.io/yaml"
+
+	miloversion "go.miloapis.com/milo/pkg/version"
 )
 
 // NewCommand creates a version command that displays version information
@@ -18,7 +19,7 @@ func NewCommand() *cobra.Command {
 		Short: "Print version information",
 		Long:  "Print version information for the Milo binary",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			versionInfo := version.Get()
+			versionInfo := miloversion.Get()
 
 			switch output {
 			case "json":
@@ -34,9 +35,10 @@ func NewCommand() *cobra.Command {
 				}
 				fmt.Print(string(data))
 			case "short":
-				fmt.Printf("Milo %s\n", versionInfo.GitVersion)
+				fmt.Printf("Milo %s\n", versionInfo.MiloVersion)
 			default:
-				fmt.Printf("Milo version: %s\n", versionInfo.GitVersion)
+				fmt.Printf("Milo version: %s\n", versionInfo.MiloVersion)
+				fmt.Printf("Kubernetes API version: %s\n", versionInfo.GitVersion)
 				fmt.Printf("Git commit: %s\n", versionInfo.GitCommit)
 				fmt.Printf("Git tree state: %s\n", versionInfo.GitTreeState)
 				fmt.Printf("Build date: %s\n", versionInfo.BuildDate)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,57 @@
+// Package version exposes the Milo release a binary was built from.
+//
+// The Kubernetes version machinery in k8s.io/component-base/version also
+// carries a version, but that value has a second job: the API server parses it
+// to derive the binary version used for feature gates and compatibility
+// validation, so it reports the Kubernetes API level Milo implements rather
+// than Milo's own release. This package keeps the Milo release available
+// alongside it.
+//
+// Values are injected at build time with -ldflags -X (see the Dockerfile).
+package version
+
+import (
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
+	baseversion "k8s.io/component-base/version"
+)
+
+// Defaults describe an ad-hoc build (e.g. `go build ./cmd/milo`) that was not
+// given version information through ldflags.
+var (
+	version      = "v0.0.0-dev"
+	gitCommit    = "unknown"
+	gitTreeState = "dirty"
+	buildDate    = "unknown"
+)
+
+// Info reports the Milo release together with the standard Kubernetes version
+// information the API server serves on /version.
+type Info struct {
+	// MiloVersion is the Milo release this binary was built from, such as
+	// "v0.32.5". GitVersion reports the Kubernetes API level instead.
+	MiloVersion string `json:"miloVersion"`
+
+	apimachineryversion.Info
+}
+
+// Get returns the version information for this binary.
+func Get() Info {
+	info := baseversion.Get()
+
+	// Fall back to this package's values when the Kubernetes machinery was not
+	// given build information, so the two never disagree.
+	if info.GitCommit == "" || info.GitCommit == "$Format:%H$" {
+		info.GitCommit = gitCommit
+	}
+	if info.GitTreeState == "" {
+		info.GitTreeState = gitTreeState
+	}
+	if info.BuildDate == "" || info.BuildDate == "1970-01-01T00:00:00Z" {
+		info.BuildDate = buildDate
+	}
+
+	return Info{
+		MiloVersion: version,
+		Info:        info,
+	}
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,49 @@
+package version
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	baseversion "k8s.io/component-base/version"
+)
+
+// TestKubernetesVersionMatchesGoMod guards the assumption the Dockerfile makes
+// when it builds the served gitVersion: that the Kubernetes minor version
+// derived from the k8s.io/component-base requirement in go.mod matches the
+// binary version the vendored libraries default to. A dependency bump that
+// changes one without the other would make the API server report a Kubernetes
+// API level it does not implement.
+func TestKubernetesVersionMatchesGoMod(t *testing.T) {
+	data, err := os.ReadFile("../../go.mod")
+	if err != nil {
+		t.Fatalf("read go.mod: %v", err)
+	}
+
+	re := regexp.MustCompile(`(?m)^\s*k8s\.io/component-base (v[0-9]+\.[0-9]+\.[0-9]+\S*)`)
+	match := re.FindSubmatch(data)
+	if match == nil {
+		t.Fatal("no k8s.io/component-base requirement found in go.mod")
+	}
+
+	parts := strings.Split(strings.TrimPrefix(string(match[1]), "v"), ".")
+	fromGoMod := fmt.Sprintf("1.%s", parts[1])
+
+	if fromGoMod != baseversion.DefaultKubeBinaryVersion {
+		t.Errorf("go.mod requires k8s.io/component-base %s (Kubernetes %s), but DefaultKubeBinaryVersion is %s; "+
+			"update the vendored dependencies together", match[1], fromGoMod, baseversion.DefaultKubeBinaryVersion)
+	}
+}
+
+func TestGetReportsMiloVersion(t *testing.T) {
+	info := Get()
+
+	if info.MiloVersion == "" {
+		t.Error("MiloVersion is empty")
+	}
+	if info.GitVersion == "" {
+		t.Error("GitVersion is empty")
+	}
+}


### PR DESCRIPTION
Fixes #511

## Problem

`kubectl version` and `datumctl version` fail against Milo and exit non-zero, because the API server serves a placeholder version string that neither can parse. Nobody can answer "which version are you running?" from the API, and `datumctl version` can't be used in a script or health check.

## What users get

```yaml
# Before
gitVersion: "v0.0.0-master+$Format:%H$"   # kubectl: parse error, exit 1
gitCommit: "$Format:%H$"
gitTreeState: ""
buildDate: "1970-01-01T00:00:00Z"
---
# After (image built from tag v0.32.5)
gitVersion: "v1.35.0-milo.0.32.5+8f3a1c2"  # valid semver
gitCommit: "8f3a1c2e9d4b7a6f5c3e1d0b9a8f7e6d5c4b3a29"
gitTreeState: "clean"
buildDate: "2026-08-26T14:02:11Z"
```

`gitVersion` reports the Kubernetes API level Milo implements and carries the Milo release in the pre-release segment. It can't simply be `v0.32.5`: the API server parses this field to derive its feature-gate version, and Milo's major-0 tags fail that validation — the obvious fix works on branch builds and breaks the server on the next tagged release. `milo version` reports the Milo release on its own line, and `-o json|yaml` gains a `miloVersion` field.

The `.dockerignore` change is unrelated to the version fix — a stale local `vendor/` tree otherwise fails the build. Happy to drop it.

## Testing

`task test:unit` passes. Release-tag rehearsal (`docker build --build-arg VERSION=v0.32.5`) produces a correct version and an API server that starts — the regression that would otherwise surface only at release time.

Follow-up: `datumctl` can surface the Milo release from the `milo.<version>` segment — see datum-cloud/datumctl#114.