### PR TITLE
fix(resourcemanager): suspension escalation email quotes true days remaining

### DIFF
--- a/internal/controllers/resourcemanager/projectsuspension_escalation_controller.go
+++ b/internal/controllers/resourcemanager/projectsuspension_escalation_controller.go
@@ -160,12 +160,24 @@ func (r *ProjectSuspensionEscalationController) Reconcile(ctx context.Context, r
 	daysRemaining := int32(math.Ceil(remaining.Hours() / 24))
 
 	if sendWarningEmails {
+		// A single reconcile can find the project already past more than one
+		// checkpoint — after a controller gap, or when a project is first seen
+		// deep into its window. Collect every now-crossed checkpoint and send
+		// ONE e-mail quoted at the true days remaining (never the checkpoint
+		// value), so an organization is never handed conflicting countdowns
+		// (e.g. both "7 days remaining" and "3 days remaining"). The
+		// checkpoints are only recorded as notified once the e-mail is actually
+		// sent, so a skipped or errored send is retried on a later reconcile.
+		var dueCheckpoints []int32
 		for _, checkpoint := range r.notificationCheckpoints {
 			if daysRemaining > checkpoint || containsInt32(project.Status.SuspensionEscalation.NotifiedDaysRemaining, checkpoint) {
 				continue
 			}
+			dueCheckpoints = append(dueCheckpoints, checkpoint)
+		}
 
-			if err := r.sendEscalationWarningEmail(ctx, &project, checkpoint, deletionAt); err != nil {
+		if len(dueCheckpoints) > 0 {
+			if err := r.sendEscalationWarningEmail(ctx, &project, daysRemaining, deletionAt, dueCheckpoints); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to send suspension deletion warning email: %w", err)
 			}
 		}
@@ -215,9 +227,11 @@ func (r *ProjectSuspensionEscalationController) cancelEscalation(ctx context.Con
 }
 
 // sendEscalationWarningEmail notifies the project's organization contact that
-// the project will be deleted in daysRemaining days, then records the
-// checkpoint as notified so it is not sent again.
-func (r *ProjectSuspensionEscalationController) sendEscalationWarningEmail(ctx context.Context, project *resourcemanagerv1alpha.Project, daysRemaining int32, deletionAt time.Time) error {
+// the project will be deleted in daysRemaining days. checkpoints lists every
+// "days until deletion" threshold that is now crossed; they are recorded as
+// notified only once the e-mail has actually been sent, so a skipped (no
+// contact e-mail) or errored send is retried on a later reconcile.
+func (r *ProjectSuspensionEscalationController) sendEscalationWarningEmail(ctx context.Context, project *resourcemanagerv1alpha.Project, daysRemaining int32, deletionAt time.Time, checkpoints []int32) error {
 	logger := log.FromContext(ctx)
 
 	var org resourcemanagerv1alpha.Organization
@@ -280,7 +294,7 @@ func (r *ProjectSuspensionEscalationController) sendEscalationWarningEmail(ctx c
 		}
 	}
 
-	project.Status.SuspensionEscalation.NotifiedDaysRemaining = append(project.Status.SuspensionEscalation.NotifiedDaysRemaining, daysRemaining)
+	project.Status.SuspensionEscalation.NotifiedDaysRemaining = append(project.Status.SuspensionEscalation.NotifiedDaysRemaining, checkpoints...)
 	sort.Slice(project.Status.SuspensionEscalation.NotifiedDaysRemaining, func(i, j int) bool {
 		return project.Status.SuspensionEscalation.NotifiedDaysRemaining[i] > project.Status.SuspensionEscalation.NotifiedDaysRemaining[j]
 	})

--- a/internal/controllers/resourcemanager/projectsuspension_escalation_controller_test.go
+++ b/internal/controllers/resourcemanager/projectsuspension_escalation_controller_test.go
@@ -256,6 +256,55 @@ func TestProjectSuspensionEscalationController_Reconcile(t *testing.T) {
 		}
 	})
 
+	t.Run("sends a single e-mail at the true days remaining after multiple checkpoints are crossed", func(t *testing.T) {
+		ctx := context.Background()
+		// The controller missed both the 7-day and 3-day marks (a reconcile gap):
+
+		// the project is now ~1 day from deletion with only the 30-day notice sent.
+		project := newSuspendedProject("test-project", "test-org", time.Now().Add(-29*24*time.Hour))
+		project.Status.SuspensionEscalation = &resourcemanagerv1alpha1.ProjectSuspensionEscalationStatus{
+			DeletionAt:            metav1.NewTime(time.Now().Add(24 * time.Hour)),
+			NotifiedDaysRemaining: []int32{30},
+		}
+		org := newTestOrganization("test-org")
+
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(project, org).
+			WithStatusSubresource(&resourcemanagerv1alpha1.Project{}).Build()
+
+		r := &ProjectSuspensionEscalationController{
+			Client:                    c,
+			EventRecorder:             record.NewFakeRecorder(100),
+			RetentionWindowDays:       30,
+			NotificationDaysRemaining: []int{7, 3, 1},
+			EmailTemplateName:         "deletion-warning",
+			EmailNamespace:            testEmailNamespace,
+			notificationCheckpoints:   computeNotificationCheckpoints(30, []int{7, 3, 1}),
+		}
+
+		if _, err := r.Reconcile(ctx, req); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var emails notificationv1alpha1.EmailList
+		if err := c.List(ctx, &emails, client.InNamespace(testEmailNamespace)); err != nil {
+			t.Fatalf("failed to list emails: %v", err)
+		}
+		// Exactly one e-mail, quoted at the true remaining days, not one per
+		// crossed checkpoint.
+		if len(emails.Items) != 1 {
+			t.Fatalf("expected exactly 1 warning email after multiple checkpoints were crossed, got %d", len(emails.Items))
+		}
+
+		var got resourcemanagerv1alpha1.Project
+		if err := c.Get(ctx, client.ObjectKey{Name: "test-project"}, &got); err != nil {
+			t.Fatalf("failed to get project: %v", err)
+		}
+		if !containsInt32(got.Status.SuspensionEscalation.NotifiedDaysRemaining, 7) ||
+			!containsInt32(got.Status.SuspensionEscalation.NotifiedDaysRemaining, 3) {
+			t.Errorf("expected crossed checkpoints 7 and 3 recorded, got %v", got.Status.SuspensionEscalation.NotifiedDaysRemaining)
+		}
+	})
+
 	t.Run("deletes the project once the retention window elapses", func(t *testing.T) {
 		ctx := context.Background()
 		suspendedSince := time.Now().Add(-31 * 24 * time.Hour)


### PR DESCRIPTION
## Problem

When a suspended project crosses more than one notification checkpoint between reconciles (a controller gap, or first contact late into its window), the escalation controller would:

- send **multiple** warning emails back-to-back (e.g. "7 days remaining" then "3 days remaining"), and
- quote the **checkpoint value** (30/7/3/1) in the email instead of the **actual** days left — so an org could be told "7 days" when only 2 real days remained.

This is customer-facing and about a deadline that ends in deletion, so a wrong or conflicting countdown is high impact.

## Root cause

`internal/controllers/resourcemanager/projectsuspension_escalation_controller.go`

The email loop passed the fixed `checkpoint` into `sendEscalationWarningEmail` (which used it as `DaysUntilDeletion`) instead of the computed `daysRemaining`, and had no `break`, so all due checkpoints fired in one pass.

## Fix

- Collect every now-crossed checkpoint and send **one** email, quoted at the true `daysRemaining` (never the checkpoint value).
- Record checkpoints as notified **only after the email is actually sent**, so a skipped (no contact email) or errored send is retried later.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| Gap crossed 7-day + 3-day marks, ~2 days left | Two emails: "7 days" + "3 days" | One email: "2 days remaining" |
| Normal single checkpoint (7-day mark) | "7 days remaining" | "7 days remaining" |
| Org has no contact email | checkpoint not recorded → retried | checkpoint not recorded → retried |