### PR TITLE
feat: add reverse downstream namespace lookup

### DIFF
--- a/pkg/downstreamclient/doc.go
+++ b/pkg/downstreamclient/doc.go
@@ -17,6 +17,16 @@
 // collisions when aggregating resources from multiple upstream clusters into a
 // single downstream API server.
 //
+// # Reverse namespace lookup
+//
+// [UpstreamNamespaceResolver] reverses the mapping: given a downstream
+// ns-<uid> namespace name it returns the upstream cluster and namespace it was
+// projected from. [RetainingNamespaceIndex] implements it from upstream
+// namespace informers, so no credential into the downstream cluster is needed,
+// and retains entries for deleted namespaces so records about them keep
+// resolving. The contract is fail-closed: see [ErrCacheNotSynced] and
+// [ErrUpstreamNamespaceUnknown].
+//
 // Ownership is tracked through anchor ConfigMaps that carry the
 // meta.datumapis.com/* labels defined in this package. The
 // [TypedEnqueueRequestsForUpstreamOwner] handler reads those labels to

--- a/pkg/downstreamclient/reverse.go
+++ b/pkg/downstreamclient/reverse.go
@@ -1,0 +1,264 @@
+package downstreamclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	toolscache "k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+)
+
+// Errors returned by [UpstreamNamespaceResolver] implementations. Callers that
+// handle untrusted downstream data MUST distinguish them: [ErrCacheNotSynced]
+// is retryable and means "ask again shortly", while [ErrUpstreamNamespaceUnknown]
+// is terminal and means the caller has no safe attribution for the record.
+//
+// Neither error may be treated as "attribute to the platform": a downstream
+// namespace that cannot be resolved has no known tenant, and defaulting it to a
+// tenant-less bucket leaks a customer's data across the tenancy boundary.
+var (
+	// ErrCacheNotSynced indicates the resolver's backing caches have not
+	// finished their initial sync. The lookup may succeed once they have.
+	ErrCacheNotSynced = errors.New("downstreamclient: upstream namespace cache has not synced")
+
+	// ErrUpstreamNamespaceUnknown indicates no upstream namespace is known for
+	// the requested downstream namespace.
+	ErrUpstreamNamespaceUnknown = errors.New("downstreamclient: no upstream namespace known for downstream namespace")
+)
+
+// UpstreamNamespaceRef identifies the upstream namespace that a downstream
+// ns-<uid> namespace was projected from.
+type UpstreamNamespaceRef struct {
+	// ClusterName is the decoded upstream cluster name, i.e. the value of
+	// [UpstreamOwnerClusterNameLabel] with its "cluster-" prefix removed and
+	// "_" restored to "/".
+	ClusterName string
+
+	// Namespace is the upstream namespace name.
+	Namespace string
+}
+
+// IsZero reports whether the reference carries no cluster or namespace.
+func (r UpstreamNamespaceRef) IsZero() bool {
+	return r.ClusterName == "" && r.Namespace == ""
+}
+
+// UpstreamNamespaceResolver reverses the ns-<uid> mapping applied by
+// [MappedNamespaceResourceStrategy].
+//
+// The contract is deliberately fail-closed. Implementations must return
+// [ErrCacheNotSynced] while their backing caches are still warming and
+// [ErrUpstreamNamespaceUnknown] when the namespace is genuinely unknown, and
+// must never return a zero-valued reference with a nil error.
+type UpstreamNamespaceResolver interface {
+	// ResolveUpstreamNamespace returns the upstream namespace that
+	// downstreamNamespace was projected from.
+	ResolveUpstreamNamespace(ctx context.Context, downstreamNamespace string) (UpstreamNamespaceRef, error)
+
+	// HasSynced reports whether every backing cache has completed its initial
+	// sync. Readiness probes should gate on this rather than on a listener
+	// being bound, so that traffic is never accepted against a cold cache.
+	HasSynced() bool
+}
+
+// EncodeUpstreamClusterName renders a cluster name in the form stored in
+// [UpstreamOwnerClusterNameLabel].
+func EncodeUpstreamClusterName(clusterName string) string {
+	return fmt.Sprintf("cluster-%s", strings.ReplaceAll(clusterName, "/", "_"))
+}
+
+// DecodeUpstreamClusterName reverses [EncodeUpstreamClusterName].
+func DecodeUpstreamClusterName(encoded string) string {
+	return strings.ReplaceAll(strings.TrimPrefix(encoded, "cluster-"), "_", "/")
+}
+
+// DownstreamNamespaceName renders the downstream namespace name for an upstream
+// namespace UID.
+func DownstreamNamespaceName(upstreamNamespaceUID types.UID) string {
+	return fmt.Sprintf("ns-%s", upstreamNamespaceUID)
+}
+
+// UpstreamNamespaceRefFromDownstreamNamespace reads the meta.datumapis.com/*
+// labels a projected namespace carries and returns the upstream namespace they
+// describe. The second return value is false when the namespace carries no
+// upstream labels, which is the normal case for namespaces that were not
+// created by [MappedNamespaceResourceStrategy].
+func UpstreamNamespaceRefFromDownstreamNamespace(namespace *corev1.Namespace) (UpstreamNamespaceRef, bool) {
+	if namespace == nil {
+		return UpstreamNamespaceRef{}, false
+	}
+
+	encodedCluster, hasCluster := namespace.Labels[UpstreamOwnerClusterNameLabel]
+	upstreamNamespace, hasNamespace := namespace.Labels[UpstreamOwnerNamespaceLabel]
+	if !hasCluster || !hasNamespace || encodedCluster == "" || upstreamNamespace == "" {
+		return UpstreamNamespaceRef{}, false
+	}
+
+	return UpstreamNamespaceRef{
+		ClusterName: DecodeUpstreamClusterName(encodedCluster),
+		Namespace:   upstreamNamespace,
+	}, true
+}
+
+// RetainingNamespaceIndex is an [UpstreamNamespaceResolver] backed by an
+// in-memory index that only ever grows.
+//
+// Retention is the point. An informer cache drops an object when it is deleted,
+// but records *about* a deleted namespace stay queryable for their full
+// retention window and must keep resolving long after the namespace is gone.
+// A plain informer cache would start failing those lookups the moment a project
+// namespace is torn down, so entries here are never removed. Use [Snapshot] and
+// [Restore] to carry the index across process restarts.
+//
+// The zero value is not usable; construct with [NewRetainingNamespaceIndex].
+type RetainingNamespaceIndex struct {
+	mu      sync.RWMutex
+	entries map[string]UpstreamNamespaceRef
+
+	syncedFuncs []toolscache.InformerSynced
+}
+
+var _ UpstreamNamespaceResolver = (*RetainingNamespaceIndex)(nil)
+
+// NewRetainingNamespaceIndex returns an empty index.
+func NewRetainingNamespaceIndex() *RetainingNamespaceIndex {
+	return &RetainingNamespaceIndex{entries: map[string]UpstreamNamespaceRef{}}
+}
+
+// Upsert records the upstream namespace for a downstream namespace name.
+// Existing entries are overwritten; entries are never removed.
+func (i *RetainingNamespaceIndex) Upsert(downstreamNamespace string, ref UpstreamNamespaceRef) {
+	if downstreamNamespace == "" || ref.IsZero() {
+		return
+	}
+
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.entries[downstreamNamespace] = ref
+}
+
+// Len returns the number of indexed namespaces.
+func (i *RetainingNamespaceIndex) Len() int {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return len(i.entries)
+}
+
+// ResolveUpstreamNamespace implements [UpstreamNamespaceResolver].
+func (i *RetainingNamespaceIndex) ResolveUpstreamNamespace(_ context.Context, downstreamNamespace string) (UpstreamNamespaceRef, error) {
+	i.mu.RLock()
+	ref, ok := i.entries[downstreamNamespace]
+	i.mu.RUnlock()
+
+	if ok {
+		return ref, nil
+	}
+
+	if !i.HasSynced() {
+		return UpstreamNamespaceRef{}, fmt.Errorf("%w: %q", ErrCacheNotSynced, downstreamNamespace)
+	}
+
+	return UpstreamNamespaceRef{}, fmt.Errorf("%w: %q", ErrUpstreamNamespaceUnknown, downstreamNamespace)
+}
+
+// HasSynced implements [UpstreamNamespaceResolver]. An index with no registered
+// sources is never considered synced, so that a misconfigured deployment fails
+// its readiness probe instead of silently failing every lookup closed.
+func (i *RetainingNamespaceIndex) HasSynced() bool {
+	i.mu.RLock()
+	syncedFuncs := make([]toolscache.InformerSynced, len(i.syncedFuncs))
+	copy(syncedFuncs, i.syncedFuncs)
+	i.mu.RUnlock()
+
+	if len(syncedFuncs) == 0 {
+		return false
+	}
+
+	for _, synced := range syncedFuncs {
+		if !synced() {
+			return false
+		}
+	}
+	return true
+}
+
+// Snapshot returns a copy of the index contents, keyed by downstream namespace
+// name. Callers persist this so that mappings for namespaces deleted while the
+// process was down survive a restart.
+func (i *RetainingNamespaceIndex) Snapshot() map[string]UpstreamNamespaceRef {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+
+	out := make(map[string]UpstreamNamespaceRef, len(i.entries))
+	for k, v := range i.entries {
+		out[k] = v
+	}
+	return out
+}
+
+// Restore merges a previously taken [Snapshot] back into the index. Entries
+// already present are left untouched, so live informer state always wins over
+// persisted state.
+func (i *RetainingNamespaceIndex) Restore(snapshot map[string]UpstreamNamespaceRef) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	for downstreamNamespace, ref := range snapshot {
+		if downstreamNamespace == "" || ref.IsZero() {
+			continue
+		}
+		if _, exists := i.entries[downstreamNamespace]; !exists {
+			i.entries[downstreamNamespace] = ref
+		}
+	}
+}
+
+// AddSyncedFunc registers a cache-sync predicate that [HasSynced] must observe
+// as true. Sources that populate the index without an informer (a restored
+// snapshot, a test fixture) should register a func that returns true.
+func (i *RetainingNamespaceIndex) AddSyncedFunc(synced toolscache.InformerSynced) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.syncedFuncs = append(i.syncedFuncs, synced)
+}
+
+// IndexUpstreamCluster wires an upstream cluster's namespace informer into the
+// index. Every namespace observed on that cluster is recorded under the
+// downstream name it projects to, so the reverse lookup needs no read against
+// the downstream cluster and no credential into it.
+//
+// The returned error only covers informer setup; population happens
+// asynchronously and is observable through [RetainingNamespaceIndex.HasSynced].
+func (i *RetainingNamespaceIndex) IndexUpstreamCluster(ctx context.Context, clusterName string, upstreamCache cache.Cache) error {
+	informer, err := upstreamCache.GetInformer(ctx, &corev1.Namespace{})
+	if err != nil {
+		return fmt.Errorf("failed getting namespace informer for cluster %q: %w", clusterName, err)
+	}
+
+	record := func(obj any) {
+		namespace, ok := obj.(*corev1.Namespace)
+		if !ok {
+			return
+		}
+		i.Upsert(DownstreamNamespaceName(namespace.UID), UpstreamNamespaceRef{
+			ClusterName: clusterName,
+			Namespace:   namespace.Name,
+		})
+	}
+
+	if _, err := informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { record(obj) },
+		UpdateFunc: func(_, obj any) { record(obj) },
+	}); err != nil {
+		return fmt.Errorf("failed adding namespace event handler for cluster %q: %w", clusterName, err)
+	}
+
+	i.AddSyncedFunc(informer.HasSynced)
+
+	return nil
+}

--- a/pkg/downstreamclient/reverse_test.go
+++ b/pkg/downstreamclient/reverse_test.go
@@ -1,0 +1,182 @@
+package downstreamclient
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestUpstreamClusterNameRoundTrip(t *testing.T) {
+	for _, clusterName := range []string{"my-project", "root:org:project", "a/b/c"} {
+		if got := DecodeUpstreamClusterName(EncodeUpstreamClusterName(clusterName)); got != clusterName {
+			t.Errorf("round trip of %q returned %q", clusterName, got)
+		}
+	}
+}
+
+func TestUpstreamNamespaceRefFromDownstreamNamespace(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace *corev1.Namespace
+		wantRef   UpstreamNamespaceRef
+		wantOK    bool
+	}{
+		{
+			name: "labelled namespace",
+			namespace: &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+				Name: "ns-9f3c8a21",
+				Labels: map[string]string{
+					UpstreamOwnerClusterNameLabel: "cluster-my-project",
+					UpstreamOwnerNamespaceLabel:   "default",
+				},
+			}},
+			wantRef: UpstreamNamespaceRef{ClusterName: "my-project", Namespace: "default"},
+			wantOK:  true,
+		},
+		{
+			name: "path encoded cluster name",
+			namespace: &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					UpstreamOwnerClusterNameLabel: "cluster-root:org_project",
+					UpstreamOwnerNamespaceLabel:   "team-a",
+				},
+			}},
+			wantRef: UpstreamNamespaceRef{ClusterName: "root:org/project", Namespace: "team-a"},
+			wantOK:  true,
+		},
+		{
+			name: "missing namespace label",
+			namespace: &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{UpstreamOwnerClusterNameLabel: "cluster-my-project"},
+			}},
+			wantOK: false,
+		},
+		{
+			name:      "unlabelled namespace",
+			namespace: &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}},
+			wantOK:    false,
+		},
+		{
+			name:   "nil namespace",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ref, ok := UpstreamNamespaceRefFromDownstreamNamespace(tt.namespace)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && ref != tt.wantRef {
+				t.Errorf("ref = %+v, want %+v", ref, tt.wantRef)
+			}
+		})
+	}
+}
+
+func TestRetainingNamespaceIndexColdCacheIsRetryable(t *testing.T) {
+	index := NewRetainingNamespaceIndex()
+	synced := false
+	index.AddSyncedFunc(func() bool { return synced })
+
+	_, err := index.ResolveUpstreamNamespace(context.Background(), "ns-unknown")
+	if !errors.Is(err, ErrCacheNotSynced) {
+		t.Fatalf("cold cache returned %v, want ErrCacheNotSynced", err)
+	}
+
+	synced = true
+	_, err = index.ResolveUpstreamNamespace(context.Background(), "ns-unknown")
+	if !errors.Is(err, ErrUpstreamNamespaceUnknown) {
+		t.Fatalf("synced cache returned %v, want ErrUpstreamNamespaceUnknown", err)
+	}
+}
+
+func TestRetainingNamespaceIndexWithNoSourcesIsNeverSynced(t *testing.T) {
+	if NewRetainingNamespaceIndex().HasSynced() {
+		t.Fatal("index with no registered sources reported synced")
+	}
+}
+
+func TestRetainingNamespaceIndexRetainsDeletedNamespaces(t *testing.T) {
+	index := NewRetainingNamespaceIndex()
+	index.AddSyncedFunc(func() bool { return true })
+
+	ref := UpstreamNamespaceRef{ClusterName: "my-project", Namespace: "default"}
+	index.Upsert("ns-9f3c8a21", ref)
+
+	got, err := index.ResolveUpstreamNamespace(context.Background(), "ns-9f3c8a21")
+	if err != nil {
+		t.Fatalf("resolve returned %v", err)
+	}
+	if got != ref {
+		t.Fatalf("resolve returned %+v, want %+v", got, ref)
+	}
+
+	restored := NewRetainingNamespaceIndex()
+	restored.AddSyncedFunc(func() bool { return true })
+	restored.Restore(index.Snapshot())
+
+	got, err = restored.ResolveUpstreamNamespace(context.Background(), "ns-9f3c8a21")
+	if err != nil {
+		t.Fatalf("resolve after restore returned %v", err)
+	}
+	if got != ref {
+		t.Fatalf("resolve after restore returned %+v, want %+v", got, ref)
+	}
+}
+
+func TestRetainingNamespaceIndexRestoreDoesNotOverwriteLiveEntries(t *testing.T) {
+	index := NewRetainingNamespaceIndex()
+	index.AddSyncedFunc(func() bool { return true })
+
+	live := UpstreamNamespaceRef{ClusterName: "project-a", Namespace: "default"}
+	index.Upsert("ns-1", live)
+	index.Restore(map[string]UpstreamNamespaceRef{
+		"ns-1": {ClusterName: "project-b", Namespace: "stale"},
+		"ns-2": {ClusterName: "project-c", Namespace: "default"},
+	})
+
+	got, err := index.ResolveUpstreamNamespace(context.Background(), "ns-1")
+	if err != nil {
+		t.Fatalf("resolve returned %v", err)
+	}
+	if got != live {
+		t.Errorf("live entry was overwritten by restore: %+v", got)
+	}
+
+	if _, err := index.ResolveUpstreamNamespace(context.Background(), "ns-2"); err != nil {
+		t.Errorf("restored entry not resolvable: %v", err)
+	}
+}
+
+func TestRetainingNamespaceIndexIgnoresIncompleteEntries(t *testing.T) {
+	index := NewRetainingNamespaceIndex()
+	index.AddSyncedFunc(func() bool { return true })
+
+	index.Upsert("", UpstreamNamespaceRef{ClusterName: "a", Namespace: "b"})
+	index.Upsert("ns-1", UpstreamNamespaceRef{})
+
+	if index.Len() != 0 {
+		t.Fatalf("index recorded %d incomplete entries", index.Len())
+	}
+}
+
+func TestRetainingNamespaceIndexHasSyncedRequiresAllSources(t *testing.T) {
+	index := NewRetainingNamespaceIndex()
+	first, second := true, false
+	index.AddSyncedFunc(func() bool { return first })
+	index.AddSyncedFunc(func() bool { return second })
+
+	if index.HasSynced() {
+		t.Fatal("index reported synced while one source was cold")
+	}
+
+	second = true
+	if !index.HasSynced() {
+		t.Fatal("index reported unsynced once all sources were warm")
+	}
+}


### PR DESCRIPTION
## Summary

Downstream clusters hold a project's projected resources under `ns-<upstream-namespace-uid>` namespaces. Anything reading that data back out needs the reverse — which upstream cluster and namespace does this belong to? Every consumer re-derives that from the `meta.datumapis.com/*` labels itself today, and each one independently decides what to do when the answer isn't known yet. That's the risk: "the cache hasn't synced" and "this belongs to nobody" are different claims, and a consumer that collapses them attributes a customer's data to no tenant at all — which, for anything tenant-scoped, publishes it where every operator can read it.

This adds a resolver alongside the existing strategy so the mapping is owned once, in both directions, with a fail-closed contract callers can't get wrong by accident: distinct retryable and terminal errors, neither of which may be read as "attribute to the platform". The index is built from **upstream** namespace informers, so no credential into the downstream cluster is needed and a compromised downstream site can't influence what a namespace resolves to. Entries are never removed and can be persisted across restarts, because records *about* a deleted namespace must keep resolving for their full retention window. Readiness gates on cache sync rather than on a listener being bound, and an index with no registered sources reports unsynced so a misconfigured deployment fails its probe instead of silently failing every lookup closed.

Additive — no existing behaviour changes.

> [!NOTE]
> The first consumer is edge audit ingest in milo-os/activity#229, which carries a mirrored copy of this code with a TODO to delete it. It can't import this until a Milo release contains it, since taking the module today would pull `k8s.io/kubernetes` into an aggregated API server's build graph. Merging and releasing here is what removes the duplicate.

## Test plan

- [x] `go build ./...` and `go vet ./pkg/downstreamclient/...` — both exit 0
- [x] `go test ./pkg/downstreamclient/... -count=1` — 6 tests pass
- [x] A cold cache returns the retryable error and the same lookup returns the terminal one once synced; an index with no sources never reports synced
- [x] Entries survive a snapshot/restore round trip, and restore does not displace live entries
- [x] Cluster names round-trip through the label encoding, including path-style names containing `/`
- [ ] Exercised end to end by the consumer's suite (real ClickHouse, NATS and mTLS) against its mirrored copy — re-run there once this is released and the copy becomes an import

## Notes for review

#627 also touches this package (`mappednamespace.go`) for the controller-runtime v0.23 upgrade. No file overlap, but the new file imports `controller-runtime/pkg/cache`, so whichever lands second may want a look.
