### PR TITLE
feat: implement GroupMembership admission webhook to enforce existence and uniqueness constraints

### DIFF
--- a/cmd/milo/controller-manager/webhooks.go
+++ b/cmd/milo/controller-manager/webhooks.go
@@ -100,6 +100,9 @@ func registerCoreControlPlaneWebhooksWithoutNotes(mgr controllerruntime.Manager)
 	if err := iamv1alpha1webhook.SetupUserDeactivationWebhooksWithManager(mgr, SystemNamespace); err != nil {
 		return fmt.Errorf("setting up userdeactivation webhook: %w", err)
 	}
+	if err := iamv1alpha1webhook.SetupGroupMembershipWebhooksWithManager(mgr); err != nil {
+		return fmt.Errorf("setting up groupmembership webhook: %w", err)
+	}
 	if err := identityv1alpha1webhook.SetupUserIdentityWebhooksWithManager(mgr); err != nil {
 		return fmt.Errorf("setting up useridentity webhook: %w", err)
 	}

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -291,6 +291,28 @@ webhooks:
     service:
       name: milo-controller-manager
       namespace: milo-system
+      path: /validate-iam-miloapis-com-v1alpha1-groupmembership
+      port: 9443
+  failurePolicy: Fail
+  name: vgroupmembership.iam.miloapis.com
+  rules:
+  - apiGroups:
+    - iam.miloapis.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - groupmemberships
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: milo-controller-manager
+      namespace: milo-system
       path: /validate-iam-miloapis-com-v1alpha1-platformaccess
       port: 9443
   failurePolicy: Fail

--- a/internal/webhooks/iam/v1alpha1/groupmembership_webhook.go
+++ b/internal/webhooks/iam/v1alpha1/groupmembership_webhook.go
@@ -1,0 +1,132 @@
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	iamv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
+)
+
+// groupmembershiplog is for logging in this package.
+var groupmembershiplog = logf.Log.WithName("groupmembership-resource")
+
+const groupMembershipCompositeKey = "iam.miloapis.com/groupmembership-composite"
+
+func buildGroupMembershipCompositeKey(userRef iamv1alpha1.UserReference, groupRef iamv1alpha1.GroupReference) string {
+	return fmt.Sprintf("%s|%s|%s", userRef.Name, groupRef.Namespace, groupRef.Name)
+}
+
+// +kubebuilder:webhook:path=/validate-iam-miloapis-com-v1alpha1-groupmembership,mutating=false,failurePolicy=fail,sideEffects=None,groups=iam.miloapis.com,resources=groupmemberships,verbs=create;update,versions=v1alpha1,name=vgroupmembership.iam.miloapis.com,admissionReviewVersions={v1,v1beta1},serviceName=milo-controller-manager,servicePort=9443,serviceNamespace=milo-system
+
+// +kubebuilder:rbac:groups=iam.miloapis.com,resources=groupmemberships,verbs=list
+// +kubebuilder:rbac:groups=iam.miloapis.com,resources=users,verbs=get
+// +kubebuilder:rbac:groups=iam.miloapis.com,resources=groups,verbs=get
+
+// SetupGroupMembershipWebhooksWithManager sets up the groupmembership webhook.
+func SetupGroupMembershipWebhooksWithManager(mgr ctrl.Manager) error {
+	groupmembershiplog.Info("Setting up iam.miloapis.com groupmembership webhooks")
+
+	// Composite index for exact membership tuple (user name + group ns + group name)
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &iamv1alpha1.GroupMembership{}, groupMembershipCompositeKey, func(rawObj client.Object) []string {
+		gm := rawObj.(*iamv1alpha1.GroupMembership)
+		return []string{buildGroupMembershipCompositeKey(gm.Spec.UserRef, gm.Spec.GroupRef)}
+	}); err != nil {
+		return fmt.Errorf("failed to index groupmembership composite key: %w", err)
+	}
+
+	return ctrl.NewWebhookManagedBy(mgr, &iamv1alpha1.GroupMembership{}).
+		WithValidator(&GroupMembershipValidator{
+			client: mgr.GetClient(),
+		}).
+		Complete()
+}
+
+// GroupMembershipValidator validates GroupMemberships.
+//
+// Invariants enforced on create:
+//   - The referenced User must exist.
+//   - The referenced Group must exist.
+//   - A user may be a member of a given group at most once within a namespace.
+//
+// Updates are rejected outright because a GroupMembership is a pure (user,
+// group) link with no mutable spec. Delete and recreate the membership to
+// change which user belongs to which group.
+type GroupMembershipValidator struct {
+	client client.Client
+}
+
+func (v *GroupMembershipValidator) ValidateCreate(ctx context.Context, membership *iamv1alpha1.GroupMembership) (admission.Warnings, error) {
+	groupmembershiplog.Info("Validating GroupMembership create", "name", membership.Name, "namespace", membership.Namespace)
+
+	var errs field.ErrorList
+
+	// Validate referenced User exists
+	user := &iamv1alpha1.User{}
+	if err := v.client.Get(ctx, client.ObjectKey{Name: membership.Spec.UserRef.Name}, user); err != nil {
+		if errors.IsNotFound(err) {
+			errs = append(errs, field.NotFound(field.NewPath("spec", "userRef", "name"), membership.Spec.UserRef.Name))
+		} else {
+			return nil, errors.NewInternalError(fmt.Errorf("failed to get User %q: %w", membership.Spec.UserRef.Name, err))
+		}
+	}
+
+	// Validate referenced Group exists
+	group := &iamv1alpha1.Group{}
+	if err := v.client.Get(ctx, client.ObjectKey{
+		Namespace: membership.Spec.GroupRef.Namespace,
+		Name:      membership.Spec.GroupRef.Name,
+	}, group); err != nil {
+		if errors.IsNotFound(err) {
+			errs = append(errs, field.NotFound(field.NewPath("spec", "groupRef", "name"), membership.Spec.GroupRef.Name))
+		} else {
+			return nil, errors.NewInternalError(fmt.Errorf("failed to get Group %q in namespace %q: %w", membership.Spec.GroupRef.Name, membership.Spec.GroupRef.Namespace, err))
+		}
+	}
+
+	// Check for duplicate membership in the same namespace
+	key := buildGroupMembershipCompositeKey(membership.Spec.UserRef, membership.Spec.GroupRef)
+	var existing iamv1alpha1.GroupMembershipList
+	if err := v.client.List(ctx, &existing,
+		client.InNamespace(membership.Namespace),
+		client.MatchingFields{groupMembershipCompositeKey: key}); err != nil {
+		return nil, errors.NewInternalError(fmt.Errorf("failed to list group memberships: %w", err))
+	}
+	if len(existing.Items) > 0 {
+		dup := field.Duplicate(field.NewPath("spec"), key)
+		dup.Detail = fmt.Sprintf("user %q is already a member of group %q in namespace %q",
+			membership.Spec.UserRef.Name,
+			membership.Spec.GroupRef.Name,
+			membership.Spec.GroupRef.Namespace,
+		)
+		errs = append(errs, dup)
+	}
+
+	if len(errs) > 0 {
+		return nil, errors.NewInvalid(iamv1alpha1.SchemeGroupVersion.WithKind("GroupMembership").GroupKind(), membership.Name, errs)
+	}
+
+	return nil, nil
+}
+
+func (v *GroupMembershipValidator) ValidateUpdate(ctx context.Context, oldMembership, newMembership *iamv1alpha1.GroupMembership) (admission.Warnings, error) {
+	groupmembershiplog.Info("Validating GroupMembership update", "name", newMembership.Name, "namespace", newMembership.Namespace)
+
+	var errs field.ErrorList
+	errs = append(errs, field.Forbidden(
+		field.NewPath("spec"),
+		fmt.Sprintf("cannot update group membership %q: group memberships are immutable. Delete and recreate the membership to change which user belongs to which group", newMembership.Name),
+	))
+
+	return nil, errors.NewInvalid(iamv1alpha1.SchemeGroupVersion.WithKind("GroupMembership").GroupKind(), newMembership.Name, errs)
+}
+
+func (v *GroupMembershipValidator) ValidateDelete(ctx context.Context, obj *iamv1alpha1.GroupMembership) (admission.Warnings, error) {
+	return nil, nil
+}

--- a/internal/webhooks/iam/v1alpha1/groupmembership_webhook_test.go
+++ b/internal/webhooks/iam/v1alpha1/groupmembership_webhook_test.go
@@ -1,0 +1,193 @@
+package v1alpha1
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	iamv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newGroupMembership(name, namespace, user, group, groupNamespace string) *iamv1alpha1.GroupMembership {
+	return &iamv1alpha1.GroupMembership{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: iamv1alpha1.GroupMembershipSpec{
+			UserRef: iamv1alpha1.UserReference{Name: user},
+			GroupRef: iamv1alpha1.GroupReference{
+				Name:      group,
+				Namespace: groupNamespace,
+			},
+		},
+	}
+}
+
+func newUser(name string) *iamv1alpha1.User {
+	return &iamv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+}
+
+func newGroup(name, namespace string) *iamv1alpha1.Group {
+	return &iamv1alpha1.Group{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+	}
+}
+
+func newTestValidator(objects ...client.Object) *GroupMembershipValidator {
+	builder := fake.NewClientBuilder().
+		WithScheme(runtimeScheme).
+		WithIndex(&iamv1alpha1.GroupMembership{}, groupMembershipCompositeKey, func(rawObj client.Object) []string {
+			gm := rawObj.(*iamv1alpha1.GroupMembership)
+			return []string{buildGroupMembershipCompositeKey(gm.Spec.UserRef, gm.Spec.GroupRef)}
+		})
+	if len(objects) > 0 {
+		builder = builder.WithObjects(objects...)
+	}
+	return &GroupMembershipValidator{
+		client: builder.Build(),
+	}
+}
+
+func TestGroupMembership_Create_Valid(t *testing.T) {
+	v := newTestValidator(
+		newUser("alice"),
+		newGroup("eng", "ns1"),
+	)
+
+	membership := newGroupMembership("gm-1", "ns1", "alice", "eng", "ns1")
+	_, err := v.ValidateCreate(context.Background(), membership)
+	require.NoError(t, err)
+}
+
+func TestGroupMembership_Create_DuplicateRejected(t *testing.T) {
+	existing := newGroupMembership("gm-1", "ns1", "alice", "eng", "ns1")
+	v := newTestValidator(
+		newUser("alice"),
+		newGroup("eng", "ns1"),
+		existing,
+	)
+
+	membership := newGroupMembership("gm-2", "ns1", "alice", "eng", "ns1")
+	_, err := v.ValidateCreate(context.Background(), membership)
+	require.Error(t, err, "duplicate user/group pair must be rejected")
+	assert.Contains(t, err.Error(), "alice")
+	assert.Contains(t, err.Error(), "eng")
+	assert.Contains(t, strings.ToLower(err.Error()), "already a member")
+}
+
+func TestGroupMembership_Create_DuplicateInDifferentGroupAllowed(t *testing.T) {
+	existing := newGroupMembership("gm-1", "ns1", "alice", "eng", "ns1")
+	v := newTestValidator(
+		newUser("alice"),
+		newGroup("eng", "ns1"),
+		newGroup("design", "ns1"),
+		existing,
+	)
+
+	membership := newGroupMembership("gm-2", "ns1", "alice", "design", "ns1")
+	_, err := v.ValidateCreate(context.Background(), membership)
+	require.NoError(t, err, "same user in a different group is allowed")
+}
+
+func TestGroupMembership_Create_DuplicateDifferentUserAllowed(t *testing.T) {
+	existing := newGroupMembership("gm-1", "ns1", "alice", "eng", "ns1")
+	v := newTestValidator(
+		newUser("alice"),
+		newUser("bob"),
+		newGroup("eng", "ns1"),
+		existing,
+	)
+
+	membership := newGroupMembership("gm-2", "ns1", "bob", "eng", "ns1")
+	_, err := v.ValidateCreate(context.Background(), membership)
+	require.NoError(t, err, "a different user in the same group is allowed")
+}
+
+func TestGroupMembership_Create_DuplicateDifferentNamespaceAllowed(t *testing.T) {
+	existing := newGroupMembership("gm-1", "ns1", "alice", "eng", "ns1")
+	v := newTestValidator(
+		newUser("alice"),
+		newGroup("eng", "ns1"),
+		newGroup("eng", "ns2"),
+		existing,
+	)
+
+	membership := newGroupMembership("gm-2", "ns2", "alice", "eng", "ns2")
+	_, err := v.ValidateCreate(context.Background(), membership)
+	require.NoError(t, err, "memberships in different namespaces are independent")
+}
+
+func TestGroupMembership_Create_UserDoesNotExistRejected(t *testing.T) {
+	v := newTestValidator(
+		newGroup("eng", "ns1"),
+	)
+
+	membership := newGroupMembership("gm-1", "ns1", "ghost", "eng", "ns1")
+	_, err := v.ValidateCreate(context.Background(), membership)
+	require.Error(t, err, "a create referencing a missing user must be rejected")
+	assert.Contains(t, err.Error(), `"ghost"`)
+}
+
+func TestGroupMembership_Create_GroupDoesNotExistRejected(t *testing.T) {
+	v := newTestValidator(
+		newUser("alice"),
+	)
+
+	membership := newGroupMembership("gm-1", "ns1", "alice", "ghost-group", "ns1")
+	_, err := v.ValidateCreate(context.Background(), membership)
+	require.Error(t, err, "a create referencing a missing group must be rejected")
+	assert.Contains(t, err.Error(), `"ghost-group"`)
+}
+
+func TestGroupMembership_Update_AnyUpdateRejected(t *testing.T) {
+	oldMembership := newGroupMembership("gm-1", "ns1", "alice", "eng", "ns1")
+	newMembership := newGroupMembership("gm-1", "ns1", "alice", "eng", "ns1")
+	v := newTestValidator()
+
+	_, err := v.ValidateUpdate(context.Background(), oldMembership, newMembership)
+	require.Error(t, err, "any update must be rejected")
+	assert.Contains(t, err.Error(), "immutable")
+}
+
+func TestGroupMembership_Update_ChangeGroupRejected(t *testing.T) {
+	oldMembership := newGroupMembership("gm-1", "ns1", "alice", "eng", "ns1")
+	updated := newGroupMembership("gm-1", "ns1", "alice", "design", "ns1")
+	v := newTestValidator()
+
+	_, err := v.ValidateUpdate(context.Background(), oldMembership, updated)
+	require.Error(t, err, "changing the group pointer must be rejected")
+	assert.Contains(t, err.Error(), "immutable")
+}
+
+func TestGroupMembership_Update_ChangeUserRejected(t *testing.T) {
+	oldMembership := newGroupMembership("gm-1", "ns1", "alice", "eng", "ns1")
+	updated := newGroupMembership("gm-1", "ns1", "bob", "eng", "ns1")
+	v := newTestValidator()
+
+	_, err := v.ValidateUpdate(context.Background(), oldMembership, updated)
+	require.Error(t, err, "changing the user pointer must be rejected")
+	assert.Contains(t, err.Error(), "immutable")
+}
+
+func TestGroupMembership_Update_ChangeGroupNamespaceRejected(t *testing.T) {
+	oldMembership := newGroupMembership("gm-1", "ns1", "alice", "eng", "ns1")
+	updated := newGroupMembership("gm-1", "ns1", "alice", "eng", "ns2")
+	v := newTestValidator()
+
+	_, err := v.ValidateUpdate(context.Background(), oldMembership, updated)
+	require.Error(t, err, "changing the referenced group namespace must be rejected")
+	assert.Contains(t, err.Error(), "immutable")
+}
+
+func TestGroupMembership_Delete_Allowed(t *testing.T) {
+	membership := newGroupMembership("gm-1", "ns1", "alice", "eng", "ns1")
+	v := newTestValidator()
+
+	_, err := v.ValidateDelete(context.Background(), membership)
+	require.NoError(t, err, "deletion must be allowed")
+}

--- a/test/iam/groupmembership-duplicate-prevention/README.md
+++ b/test/iam/groupmembership-duplicate-prevention/README.md
@@ -1,0 +1,129 @@
+# Test: `groupmembership-duplicate-prevention`
+
+Verifies the GroupMembership validating webhook prevents a user from being
+added to the same group more than once, rejects non-existent group and user
+references, and prevents an existing membership from being updated.
+
+This test verifies:
+- Creating the first membership for a (user, group) pair succeeds.
+- Creating a second membership for the same (user, group) pair is rejected
+  at admission.
+- A different user can still join the same group.
+- A user can join a different group.
+- Creating a membership referencing a non-existent group is rejected at admission.
+- Creating a membership referencing a non-existent user is rejected at admission.
+- Updating an existing membership is rejected because group memberships are immutable.
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [setup-users-and-groups](#step-setup-users-and-groups) | 0 | 4 | 0 | 0 | 0 |
+| 2 | [create-first-membership](#step-create-first-membership) | 0 | 2 | 0 | 0 | 0 |
+| 3 | [reject-duplicate-membership](#step-reject-duplicate-membership) | 0 | 1 | 0 | 0 | 0 |
+| 4 | [allow-different-user-same-group](#step-allow-different-user-same-group) | 0 | 2 | 0 | 0 | 0 |
+| 5 | [allow-same-user-different-group](#step-allow-same-user-different-group) | 0 | 2 | 0 | 0 | 0 |
+| 6 | [reject-nonexistent-group](#step-reject-nonexistent-group) | 0 | 1 | 0 | 0 | 0 |
+| 7 | [reject-nonexistent-user](#step-reject-nonexistent-user) | 0 | 1 | 0 | 0 | 0 |
+| 8 | [reject-reference-update](#step-reject-reference-update) | 0 | 1 | 0 | 0 | 0 |
+| 9 | [reject-any-update](#step-reject-any-update) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `setup-users-and-groups`
+
+Create required Users and Groups for testing group memberships.
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `apply` | 0 | 0 | *No description* |
+| 3 | `assert` | 0 | 0 | *No description* |
+| 4 | `assert` | 0 | 0 | *No description* |
+
+### Step: `create-first-membership`
+
+The first membership linking a user to a group is accepted.
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `reject-duplicate-membership`
+
+A second membership for the same (user, group) pair is rejected by the webhook.
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `allow-different-user-same-group`
+
+A different user may still join the same group.
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `allow-same-user-different-group`
+
+The same user may join a different group.
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `reject-nonexistent-group`
+
+Creating a membership referencing a non-existent group is rejected.
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `reject-nonexistent-user`
+
+Creating a membership referencing a non-existent user is rejected.
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `reject-reference-update`
+
+Applying a change to an existing membership's group pointer is rejected because group memberships are immutable.
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `reject-any-update`
+
+Re-applying an existing membership is rejected because group memberships are immutable.
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+---
+

--- a/test/iam/groupmembership-duplicate-prevention/chainsaw-test.yaml
+++ b/test/iam/groupmembership-duplicate-prevention/chainsaw-test.yaml
@@ -1,0 +1,103 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: groupmembership-duplicate-prevention
+spec:
+  description: |
+    Verifies the GroupMembership validating webhook prevents a user from being
+    added to the same group more than once, rejects non-existent group and user
+    references, and prevents an existing membership from being updated.
+
+    This test verifies:
+    - Creating the first membership for a (user, group) pair succeeds.
+    - Creating a second membership for the same (user, group) pair is rejected
+      at admission.
+    - A different user can still join the same group.
+    - A user can join a different group.
+    - Creating a membership referencing a non-existent group is rejected at admission.
+    - Creating a membership referencing a non-existent user is rejected at admission.
+    - Updating an existing membership is rejected because group memberships are immutable.
+
+  steps:
+  - name: setup-users-and-groups
+    description: Create required Users and Groups for testing group memberships.
+    try:
+    - apply:
+        file: resources/users.yaml
+    - apply:
+        file: resources/groups.yaml
+    - assert:
+        file: resources/users.yaml
+    - assert:
+        file: resources/groups.yaml
+
+  - name: create-first-membership
+    description: The first membership linking a user to a group is accepted.
+    try:
+    - apply:
+        file: resources/membership-alice-eng.yaml
+    - assert:
+        file: resources/membership-alice-eng.yaml
+
+  - name: reject-duplicate-membership
+    description: A second membership for the same (user, group) pair is rejected by the webhook.
+    try:
+    - apply:
+        file: resources/membership-alice-eng-duplicate.yaml
+        expect:
+        - check:
+            ($error != null): true
+
+  - name: allow-different-user-same-group
+    description: A different user may still join the same group.
+    try:
+    - apply:
+        file: resources/membership-bob-eng.yaml
+    - assert:
+        file: resources/membership-bob-eng.yaml
+
+  - name: allow-same-user-different-group
+    description: The same user may join a different group.
+    try:
+    - apply:
+        file: resources/membership-alice-platform.yaml
+    - assert:
+        file: resources/membership-alice-platform.yaml
+
+  - name: reject-nonexistent-group
+    description: Creating a membership referencing a non-existent group is rejected.
+    try:
+    - apply:
+        file: resources/membership-alice-nonexistent-group.yaml
+        expect:
+        - check:
+            ($error != null): true
+
+  - name: reject-nonexistent-user
+    description: Creating a membership referencing a non-existent user is rejected.
+    try:
+    - apply:
+        file: resources/membership-nonexistent-user-eng.yaml
+        expect:
+        - check:
+            ($error != null): true
+
+  - name: reject-reference-update
+    description: Applying a change to an existing membership's group pointer is rejected because group memberships are immutable.
+    try:
+    - apply:
+        file: resources/membership-alice-eng-change-group.yaml
+        expect:
+        - check:
+            ($error != null): true
+
+  - name: reject-any-update
+    description: Re-applying an existing membership is rejected because group memberships are immutable.
+    try:
+    - apply:
+        file: resources/membership-alice-eng.yaml
+        expect:
+        - check:
+            ($error != null): true
+
+

--- a/test/iam/groupmembership-duplicate-prevention/resources/groups.yaml
+++ b/test/iam/groupmembership-duplicate-prevention/resources/groups.yaml
@@ -1,0 +1,11 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: Group
+metadata:
+  name: eng
+  namespace: ($namespace)
+---
+apiVersion: iam.miloapis.com/v1alpha1
+kind: Group
+metadata:
+  name: platform
+  namespace: ($namespace)

--- a/test/iam/groupmembership-duplicate-prevention/resources/membership-alice-eng-change-group.yaml
+++ b/test/iam/groupmembership-duplicate-prevention/resources/membership-alice-eng-change-group.yaml
@@ -1,0 +1,11 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: GroupMembership
+metadata:
+  name: gm-alice-eng
+  namespace: ($namespace)
+spec:
+  userRef:
+    name: alice
+  groupRef:
+    name: platform
+    namespace: ($namespace)

--- a/test/iam/groupmembership-duplicate-prevention/resources/membership-alice-eng-duplicate.yaml
+++ b/test/iam/groupmembership-duplicate-prevention/resources/membership-alice-eng-duplicate.yaml
@@ -1,0 +1,11 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: GroupMembership
+metadata:
+  name: gm-alice-eng-duplicate
+  namespace: ($namespace)
+spec:
+  userRef:
+    name: alice
+  groupRef:
+    name: eng
+    namespace: ($namespace)

--- a/test/iam/groupmembership-duplicate-prevention/resources/membership-alice-eng.yaml
+++ b/test/iam/groupmembership-duplicate-prevention/resources/membership-alice-eng.yaml
@@ -1,0 +1,11 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: GroupMembership
+metadata:
+  name: gm-alice-eng
+  namespace: ($namespace)
+spec:
+  userRef:
+    name: alice
+  groupRef:
+    name: eng
+    namespace: ($namespace)

--- a/test/iam/groupmembership-duplicate-prevention/resources/membership-alice-nonexistent-group.yaml
+++ b/test/iam/groupmembership-duplicate-prevention/resources/membership-alice-nonexistent-group.yaml
@@ -1,0 +1,11 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: GroupMembership
+metadata:
+  name: gm-alice-nonexistent-group
+  namespace: ($namespace)
+spec:
+  userRef:
+    name: alice
+  groupRef:
+    name: non-existent-group
+    namespace: ($namespace)

--- a/test/iam/groupmembership-duplicate-prevention/resources/membership-alice-platform.yaml
+++ b/test/iam/groupmembership-duplicate-prevention/resources/membership-alice-platform.yaml
@@ -1,0 +1,11 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: GroupMembership
+metadata:
+  name: gm-alice-platform
+  namespace: ($namespace)
+spec:
+  userRef:
+    name: alice
+  groupRef:
+    name: platform
+    namespace: ($namespace)

--- a/test/iam/groupmembership-duplicate-prevention/resources/membership-bob-eng.yaml
+++ b/test/iam/groupmembership-duplicate-prevention/resources/membership-bob-eng.yaml
@@ -1,0 +1,11 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: GroupMembership
+metadata:
+  name: gm-bob-eng
+  namespace: ($namespace)
+spec:
+  userRef:
+    name: bob
+  groupRef:
+    name: eng
+    namespace: ($namespace)

--- a/test/iam/groupmembership-duplicate-prevention/resources/membership-nonexistent-user-eng.yaml
+++ b/test/iam/groupmembership-duplicate-prevention/resources/membership-nonexistent-user-eng.yaml
@@ -1,0 +1,11 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: GroupMembership
+metadata:
+  name: gm-nonexistent-user-eng
+  namespace: ($namespace)
+spec:
+  userRef:
+    name: non-existent-user
+  groupRef:
+    name: eng
+    namespace: ($namespace)

--- a/test/iam/groupmembership-duplicate-prevention/resources/users.yaml
+++ b/test/iam/groupmembership-duplicate-prevention/resources/users.yaml
@@ -1,0 +1,17 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: User
+metadata:
+  name: alice
+spec:
+  email: alice@example.com
+  givenName: Alice
+  familyName: Smith
+---
+apiVersion: iam.miloapis.com/v1alpha1
+kind: User
+metadata:
+  name: bob
+spec:
+  email: bob@example.com
+  givenName: Bob
+  familyName: Jones

--- a/test/resource-management/project-deletion-blocked-resources/README.md
+++ b/test/resource-management/project-deletion-blocked-resources/README.md
@@ -34,7 +34,7 @@ This test verifies, for the two places project resources live:
 | 9 | [verify-namespace-outlives-its-contents](#step-verify-namespace-outlives-its-contents) | 0 | 2 | 1 | 0 | 0 |
 | 10 | [release-finalizers](#step-release-finalizers) | 0 | 1 | 1 | 0 | 0 |
 | 11 | [verify-projects-delete-promptly](#step-verify-projects-delete-promptly) | 0 | 2 | 1 | 0 | 0 |
-| 12 | [cleanup-organization](#step-cleanup-organization) | 0 | 2 | 1 | 0 | 0 |
+| 12 | [cleanup-organization](#step-cleanup-organization) | 0 | 3 | 1 | 0 | 0 |
 
 ### Step: `clear-previous-run`
 
@@ -176,8 +176,9 @@ Remove the organization and user the test created
 
 | # | Operation | Bindings | Outputs | Description |
 |:-:|---|:-:|:-:|---|
-| 1 | `delete` | 0 | 0 | *No description* |
+| 1 | `script` | 0 | 0 | *No description* |
 | 2 | `delete` | 0 | 0 | *No description* |
+| 3 | `delete` | 0 | 0 | *No description* |
 
 ---
 


### PR DESCRIPTION
## Description

### Summary
This PR introduces a validating admission webhook for `GroupMembership` (`iam.miloapis.com/v1alpha1`) and an end-to-end Chainsaw test suite to enforce relational integrity, uniqueness, and immutability constraints.

---

### Motivation & Background
A `GroupMembership` resource models an association between a cluster-scoped `User` and a namespaced `Group`. Previously, there were no admission checks verifying whether the target `User` or `Group` existed, whether a duplicate membership had already been created in the namespace, or whether an existing membership was modified after creation.

This webhook addresses these gaps by validating invariants at admission time and rejecting invalid create and update requests with descriptive `field.ErrorList` errors.

Related to:
- https://datum-inc.slack.com/archives/C0AKA02CNKT/p1788379472119569