### PR TITLE
test(e2e): assert the Project is listed in the main control plane before deletion

### DIFF
--- a/test/resource-management/project-deletion/README.md
+++ b/test/resource-management/project-deletion/README.md
@@ -5,6 +5,7 @@ Tests Project deletion and resource cleanup.
 This test verifies:
 - A project can be deleted after reaching Ready status
 - The ResourceCleanup condition progresses through the expected states
+- The project is visible in the main cluster context before deletion
 - The project is fully removed from both organization and main cluster contexts
 
 
@@ -14,8 +15,9 @@ This test verifies:
 |:-:|---|:-:|:-:|:-:|:-:|:-:|
 | 1 | [setup-organization](#step-setup-organization) | 0 | 5 | 0 | 0 | 0 |
 | 2 | [create-project-and-wait-for-ready](#step-create-project-and-wait-for-ready) | 0 | 3 | 0 | 0 | 0 |
-| 3 | [delete-project](#step-delete-project) | 0 | 2 | 0 | 0 | 0 |
-| 4 | [verify-project-gone-from-main-cluster](#step-verify-project-gone-from-main-cluster) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [verify-project-listed-in-main-cluster](#step-verify-project-listed-in-main-cluster) | 0 | 1 | 0 | 0 | 0 |
+| 4 | [delete-project](#step-delete-project) | 0 | 2 | 0 | 0 | 0 |
+| 5 | [verify-project-gone-from-main-cluster](#step-verify-project-gone-from-main-cluster) | 0 | 1 | 0 | 0 | 0 |
 
 ### Step: `setup-organization`
 
@@ -42,6 +44,16 @@ Create Project in organization context and verify it reaches Ready status
 | 1 | `apply` | 0 | 0 | *No description* |
 | 2 | `wait` | 0 | 0 | *No description* |
 | 3 | `assert` | 0 | 0 | *No description* |
+
+### Step: `verify-project-listed-in-main-cluster`
+
+Verify the Project is visible in the main cluster before deletion
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
 
 ### Step: `delete-project`
 

--- a/test/resource-management/project-deletion/assertions/assert-project-exists-main.yaml
+++ b/test/resource-management/project-deletion/assertions/assert-project-exists-main.yaml
@@ -1,0 +1,11 @@
+apiVersion: resourcemanager.miloapis.com/v1alpha1
+kind: Project
+metadata:
+  name: project-deletion-test
+  labels:
+    test.miloapis.com/scenario: "project-deletion"
+    resourcemanager.miloapis.com/organization-name: test-project-deletion-org
+spec:
+  ownerRef:
+    kind: Organization
+    name: test-project-deletion-org

--- a/test/resource-management/project-deletion/chainsaw-test.yaml
+++ b/test/resource-management/project-deletion/chainsaw-test.yaml
@@ -9,6 +9,7 @@ spec:
     This test verifies:
     - A project can be deleted after reaching Ready status
     - The ResourceCleanup condition progresses through the expected states
+    - The project is visible in the main cluster context before deletion
     - The project is fully removed from both organization and main cluster contexts
 
   clusters:
@@ -63,6 +64,13 @@ spec:
                 value: 'True'
         - assert:
             file: assertions/assert-project-ready.yaml
+
+    - name: verify-project-listed-in-main-cluster
+      description: Verify the Project is visible in the main cluster before deletion
+      cluster: main
+      try:
+        - assert:
+            file: assertions/assert-project-exists-main.yaml
 
     - name: delete-project
       description: Delete the project and verify cleanup completes


### PR DESCRIPTION
## What

Adds one step to `test/resource-management/project-deletion`: after the Project reaches `Ready` in the org control plane and before it is deleted, assert that the main control plane lists it with the expected organization label and `ownerRef`.

## Why

The test proved the Project vanished from the main control plane after deletion but never proved it was there first. The final "gone" check could pass against a Project that was never projected into main.

This is the only assertion from infra's `project-lifecycle` Chainsaw test that `main` did not already cover. #681 carried that test as a whole new directory that duplicated `project-deletion` and had drifted from `main` (shared User name, pre-JMESPath condition assert, no README). #681 is closed in favor of this change.

Refs: datum-cloud/infra#3006

## Verification

- `README.md` updated by hand in the `chainsaw build docs` format. No Go toolchain on the authoring machine, so `task generate:test-docs` did not run. If CI regenerates docs and diffs, the regenerated file wins.
- Not run locally against a Milo apiserver. Relies on the `test-environment-validation` CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZxVq7kz9bNaDyvSxWPm4c