### PR TITLE
fix: Default ServiceAccount spec so state defaults apply

### DIFF
--- a/config/crd/bases/iam/iam.miloapis.com_serviceaccounts.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_serviceaccounts.yaml
@@ -57,6 +57,7 @@ spec:
           metadata:
             type: object
           spec:
+            default: {}
             description: ServiceAccountSpec defines the desired state of ServiceAccount
             properties:
               state:

--- a/docs/api/iam.md
+++ b/docs/api/iam.md
@@ -2350,6 +2350,8 @@ ServiceAccount is the Schema for the service accounts API
         <td>object</td>
         <td>
           ServiceAccountSpec defines the desired state of ServiceAccount<br/>
+          <br/>
+            <i>Default</i>: map[]<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/pkg/apis/iam/v1alpha1/serviceaccount_types.go
+++ b/pkg/apis/iam/v1alpha1/serviceaccount_types.go
@@ -21,6 +21,7 @@ type ServiceAccount struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// +kubebuilder:default={}
 	Spec   ServiceAccountSpec   `json:"spec,omitempty"`
 	Status ServiceAccountStatus `json:"status,omitempty"`
 }

--- a/pkg/apis/iam/v1alpha1/serviceaccount_types_crd_test.go
+++ b/pkg/apis/iam/v1alpha1/serviceaccount_types_crd_test.go
@@ -1,0 +1,52 @@
+package v1alpha1_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	sigsyaml "sigs.k8s.io/yaml"
+)
+
+// A ServiceAccount applied with no spec key must still default spec.state to
+// Active. CRD defaulting fills a nested default only when the parent object is
+// present, so the spec property itself needs a default of {}.
+func TestServiceAccountSpecDefaultsToEmptyObject(t *testing.T) {
+	crdPath := filepath.Join(repoRoot(t), "config", "crd", "bases", "iam", "iam.miloapis.com_serviceaccounts.yaml")
+	raw, err := os.ReadFile(crdPath)
+	if err != nil {
+		t.Fatalf("reading CRD: %v", err)
+	}
+
+	var crd apiextensionsv1.CustomResourceDefinition
+	if err := sigsyaml.Unmarshal(raw, &crd); err != nil {
+		t.Fatalf("unmarshaling CRD: %v", err)
+	}
+	if len(crd.Spec.Versions) == 0 {
+		t.Fatal("CRD has no versions")
+	}
+
+	schema := crd.Spec.Versions[0].Schema.OpenAPIV3Schema
+	specProp, ok := schema.Properties["spec"]
+	if !ok {
+		t.Fatal("schema missing spec property")
+	}
+	if specProp.Default == nil {
+		t.Fatal("spec property has no default; an absent spec would never default spec.state")
+	}
+	if got := string(specProp.Default.Raw); got != "{}" {
+		t.Errorf("spec default = %s, want {}", got)
+	}
+
+	stateProp, ok := specProp.Properties["state"]
+	if !ok {
+		t.Fatal("spec schema missing state property")
+	}
+	if stateProp.Default == nil {
+		t.Fatal("spec.state has no default")
+	}
+	if got := string(stateProp.Default.Raw); got != `"Active"` {
+		t.Errorf("spec.state default = %s, want \"Active\"", got)
+	}
+}


### PR DESCRIPTION
## Summary

A ServiceAccount applied with no spec stored no state, so the state column and any reader of it saw an empty value.

This change gives the spec object its own empty default. An absent spec now resolves to an empty object first, and state then defaults to Active.

Existing ServiceAccounts with no spec report state Active as soon as the new schema lands, with no write needed.

## Test plan

- [ ] A ServiceAccount created with only metadata reports state Active
- [ ] The new schema test fails against the old CRD and passes against the new one

Fixes #773
Related to #683

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZxVq7kz9bNaDyvSxWPm4c