### PR TITLE
chore: Restore e2e and test-doc tasks on a current Go toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # and cross-compiles to $TARGETOS/$TARGETARCH. This makes multi-arch builds
 # (linux/amd64, linux/arm64) fast under buildx without requiring QEMU emulation
 # for the build itself.
-FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
 
 # Provided automatically by BuildKit when using buildx with --platform.
 ARG TARGETOS

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -8,7 +8,7 @@ vars:
   # renovate: datasource=go depName=fybrik.io/crdoc
   CRDOC_VERSION: v0.6.4
   # renovate: datasource=go depName=github.com/kyverno/chainsaw
-  CHAINSAW_VERSION: v0.2.13
+  CHAINSAW_VERSION: v0.2.15
   # Container image configuration
   MILO_IMAGE_NAME: "ghcr.io/milo-os/milo"
   MILO_IMAGE_TAG: "dev"

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module go.miloapis.com/milo
 
 go 1.25.0
 
+toolchain go1.26.0
+
 require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/go-logr/logr v1.4.3

--- a/test/iam/service-account-contract/README.md
+++ b/test/iam/service-account-contract/README.md
@@ -84,3 +84,4 @@ Delete the ServiceAccount and verify it is removed
 | 2 | `error` | 0 | 0 | *No description* |
 
 ---
+

--- a/test/resource-management/project-deletion-blocked-resources/README.md
+++ b/test/resource-management/project-deletion-blocked-resources/README.md
@@ -34,7 +34,7 @@ This test verifies, for the two places project resources live:
 | 9 | [verify-namespace-outlives-its-contents](#step-verify-namespace-outlives-its-contents) | 0 | 2 | 1 | 0 | 0 |
 | 10 | [release-finalizers](#step-release-finalizers) | 0 | 1 | 1 | 0 | 0 |
 | 11 | [verify-projects-delete-promptly](#step-verify-projects-delete-promptly) | 0 | 2 | 1 | 0 | 0 |
-| 12 | [cleanup-organization](#step-cleanup-organization) | 0 | 2 | 1 | 0 | 0 |
+| 12 | [cleanup-organization](#step-cleanup-organization) | 0 | 3 | 1 | 0 | 0 |
 
 ### Step: `clear-previous-run`
 
@@ -176,8 +176,9 @@ Remove the organization and user the test created
 
 | # | Operation | Bindings | Outputs | Description |
 |:-:|---|:-:|:-:|---|
-| 1 | `delete` | 0 | 0 | *No description* |
+| 1 | `script` | 0 | 0 | *No description* |
 | 2 | `delete` | 0 | 0 | *No description* |
+| 3 | `delete` | 0 | 0 | *No description* |
 
 ---
 


### PR DESCRIPTION
## Summary

The pinned chainsaw release does not build on Go 1.26 or newer, so the e2e and test-doc tasks fail on a current local toolchain.

This change moves the pin to v0.2.15, which carries the upstream fix. The new release declares Go 1.26, so the module now names that toolchain and the builder image moves to the same version, which lifts every CI job and local build from Go 1.25 to 1.26.

Two generated test READMEs are refreshed too, one stale since August.

## Test plan

- [ ] The e2e suite installs the new release and passes
- [ ] Regenerating test docs on this branch produces no diff

Related to #779

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZxVq7kz9bNaDyvSxWPm4c