### PR TITLE
fix: Declare two correct rules empty by design

### DIFF
--- a/config/telemetry/alerts/controller-manager/controller-manager.yaml
+++ b/config/telemetry/alerts/controller-manager/controller-manager.yaml
@@ -35,6 +35,7 @@ spec:
             }[5m]) >= 1
           for: 5m
           labels:
+            expected_no_match: "true"
             severity: critical
             service: milo-controller-manager
           annotations:

--- a/config/telemetry/alerts/resources-manager/organization-memberships.yaml
+++ b/config/telemetry/alerts/resources-manager/organization-memberships.yaml
@@ -16,6 +16,7 @@ spec:
           expr: resourcemanager_miloapis_com:organizationmemberships:not_ready > 0
           for: 5m
           labels:
+            expected_no_match: "true"
             severity: warning
             category: readiness
             team: platform

--- a/docs/runbooks/organization-memberships-not-ready.md
+++ b/docs/runbooks/organization-memberships-not-ready.md
@@ -90,9 +90,21 @@ further:
 kubectl rollout restart deploy/milo-controller-manager -n <namespace>
 ```
 
+## Why This Rule Selects Nothing When Healthy
+
+The recording rule counts only memberships whose `Ready` condition is not
+`True`, so a healthy fleet produces no series at all rather than a zero. On
+production it reads 547 membership series and emits nothing.
+
+That is indistinguishable from a rule whose metric was renamed or never
+shipped, so the rule carries `expected_no_match: "true"`. The alert-compliance
+exporter reads that label and stops reporting the rule as dead. Remove the
+label if the expression ever changes to one that selects series while healthy.
+
 ## Related
 
 - [policy-bindings-not-ready.md](policy-bindings-not-ready.md) — the
   membership's owned PolicyBinding shows up here too until the membership
   self-deletes.
 - [controller-manager-crash-looping.md](controller-manager-crash-looping.md)
+


### PR DESCRIPTION
## Summary

Production reports the controller-manager crash-loop warning and the membership readiness alert as rules that have selected no series for over a week, which reads exactly like a rule whose metric was renamed or never shipped.

Both are correct as written. The crash-loop rule selects series only while the pod is in CrashLoopBackOff, and the readiness rule counts only memberships that are not Ready, reading 547 membership series on production and emitting nothing.

Both now carry a label declaring the emptiness intended, and the membership runbook records why the rule looks dead when the fleet is healthy.

## Test plan

- [ ] The no-data report on production stops naming these two rules after the next release reaches it
- [ ] A crash-looping controller and an unready membership each still raise their alert

Related to https://github.com/milo-os/milo/issues/783
Related to https://github.com/datum-cloud/infra/issues/5086

https://claude.ai/code/session_014zQEpY3TeCaSfH7nEY5Mzg
