### PR TITLE
fix: Record project suspensions in the activity timeline

### DIFF
--- a/config/services/activity/policies/resourcemanager/project-policy.yaml
+++ b/config/services/activity/policies/resourcemanager/project-policy.yaml
@@ -38,8 +38,8 @@ spec:
   eventRules:
     - name: suspended
       match: "event.reason == 'Suspended'"
-      summary: "Project {{ event.involvedObject.name }} was suspended"
+      summary: "Project {{ event.regarding.name }} was suspended"
 
     - name: reinstated
       match: "event.reason == 'Reinstated'"
-      summary: "Project {{ event.involvedObject.name }} was reinstated"
+      summary: "Project {{ event.regarding.name }} was reinstated"


### PR DESCRIPTION
## Summary

Project suspensions and reinstatements fail to become activity entries and land in the activity dead-letter queue instead, which keeps the dead-letter leak alert firing in production.

Both Project event rules read the resource name from a field that current Kubernetes events do not carry, so their summaries fail to evaluate.

Both rules now read the name from the field the activity processor provides for every event, so the entries reach the platform-wide activity feed, though the project's own timeline also needs the scoping change in #749.

Events already in the dead-letter queue are re-evaluated against the corrected rules once https://github.com/milo-os/activity/issues/216 fixes retry.

## Test plan

- [ ] In staging after merge, the activity processor logs no Project policy evaluation errors, and suspending then reinstating a staging project adds both entries to the platform feed
- [ ] After the next milo release, the Project policy stops adding to production's dead-letter queue and the leak alert clears for it

Related to https://github.com/datum-cloud/infra/issues/2919

https://claude.ai/code/session_014zQEpY3TeCaSfH7nEY5Mzg
